### PR TITLE
Acknowledgment module

### DIFF
--- a/src/acknowledgment.rs
+++ b/src/acknowledgment.rs
@@ -1,5 +1,12 @@
 use std::collections::HashMap;
 
+pub struct Acknowledment {
+    pub ack_begin: u32,
+    pub ack_end: u8,
+    pub miss_count: u8,
+    pub miss: Vec<u8>,
+}
+
 // Acknowledgments received
 pub struct AcknowledgmentCheck {
     begin: u32,
@@ -35,69 +42,81 @@ impl AcknowledgmentCheck {
 
         match self.list.get(ack) {
             None => false,
-            Some(_) => true,
+            Some(v) => *v,
         }
     }
-}
-
-struct Acknowledment {
-    ack: u32,
-    ttl: u32,
 }
 
 // Acknowledgments to be sent
 pub struct AcknowledgmentList {
-    miss: Vec<u8>,
-    sequence: u32,
+    list: HashMap<u8, bool>,
+    ack_begin: u32,
     ack_end: u8,
 }
 
 impl AcknowledgmentList {
-    pub fn new(sequence: u32) -> AcknowledgmentList {
+    pub fn new(ack_begin: u32) -> AcknowledgmentList {
+        let mut list: HashMap<u8, bool> = HashMap::new();
+        list.insert(0, true);
         AcknowledgmentList {
-            miss: Vec::new(),
-            sequence,
+            list,
+            ack_begin,
             ack_end: 0,
         }
     }
 
-    pub fn check(&self, ack: u32) {}
+    pub fn check(&self, ack: &u32) -> bool {
+        if *ack == self.ack_begin {
+            return true;
+        } else if self.ack_begin <= *ack && *ack <= (self.ack_begin + self.ack_end as u32) {
+            let n = (*ack - self.ack_begin) as u8;
+            return match self.list.get(&n) {
+                None => false,
+                Some(v) => *v,
+            };
+        } else {
+            return false;
+        }
+    }
 
     pub fn insert(&mut self, ack: u32) {
-        if ack < self.sequence {
+        if ack < self.ack_begin {
             panic!("ack too old");
         }
 
-        if ack > (0xff + self.sequence) {
+        if ack > (0xff + self.ack_begin) {
             panic!("ack too large");
         }
 
-        let n = (ack - self.sequence) as u8;
+        let n = (ack - self.ack_begin) as u8;
 
         if n > self.ack_end {
-            let mut new_miss: Vec<u8> = ((self.ack_end + 1)..n).collect();
-
-            self.miss.append(&mut new_miss);
-
             self.ack_end = n as u8;
         }
 
-        if n < self.ack_end {
-            let index = self.miss.iter().position(|&r| r == n).unwrap();
-            self.miss.swap_remove(index);
+        self.list.insert(n, true);
+    }
+
+    pub fn get(&self) -> Acknowledment {
+        let mut miss: Vec<u8> = Vec::new();
+
+        for i in 0..(self.ack_end + 1) {
+            match self.list.get(&i) {
+                None => miss.push(i),
+                Some(false) => miss.push(i),
+                Some(true) => (),
+            }
+        }
+
+        Acknowledment {
+            ack_begin: self.ack_begin,
+            ack_end: self.ack_end,
+            miss_count: miss.len() as u8,
+            miss,
         }
     }
 
-    pub fn get(&mut self) -> (u32, u8, u8, Vec<u8>) {
-        (
-            self.sequence,
-            self.ack_end,
-            self.miss.len() as u8,
-            self.miss.clone(),
-        )
-    }
-
     pub fn is_complete(&self) -> bool {
-        self.miss.len() == 0
+        self.get().miss_count == 0
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ mod packet_test {
 }
 
 #[cfg(test)]
-mod ack_test {
+mod ackcheck_test {
     use crate::acknowledgment::AcknowledgmentCheck;
 
     #[test]
@@ -61,5 +61,78 @@ mod ack_test {
         for c in values {
             assert!(ack_check.check(&c));
         }
+    }
+}
+
+#[cfg(test)]
+mod acklist_test {
+    use crate::acknowledgment::AcknowledgmentList;
+
+    #[test]
+    fn false_positives() {
+        let sequence = 10;
+        let mut ack_list = AcknowledgmentList::new(sequence);
+
+        let values = [10, 20, 30, 40];
+
+        let check = [12, 15, 320, 44, 39];
+
+        for v in values {
+            ack_list.insert(v);
+        }
+
+        for c in check {
+            assert!(!ack_list.check(&c));
+        }
+    }
+
+    #[test]
+    fn true_negatives() {
+        let sequence = 10;
+        let mut ack_list = AcknowledgmentList::new(sequence);
+
+        let values = [10, 20, 30, 40];
+
+        for v in values {
+            ack_list.insert(v);
+        }
+
+        for c in values {
+            assert!(ack_list.check(&c));
+        }
+    }
+
+    #[test]
+    fn missing_test() {
+        let sequence = 10;
+        let mut ack_list = AcknowledgmentList::new(sequence);
+
+        let misses = [11, 14, 22, 28];
+
+        for v in sequence..(sequence + 20) {
+            if !misses.contains(&v) {
+                ack_list.insert(v);
+            }
+        }
+
+        let ack = ack_list.get();
+
+        for m in ack.miss {
+            assert!(misses.contains(&(m as u32 + sequence)));
+        }
+    }
+
+    #[test]
+    fn check_complete_test() {
+        let sequence = 10;
+        let mut ack_list = AcknowledgmentList::new(sequence);
+
+        let values = sequence..(sequence + 20);
+
+        for v in values {
+            ack_list.insert(v);
+        }
+
+        assert!(ack_list.is_complete());
     }
 }


### PR DESCRIPTION
Created `AcknowledgmentCheck` module
- Implemented an acknowledment check list which stores incoming acknowledgments.
- Sending module can use this to check if a packet has already been acknowledged using this module

Created `AcknowledgmentList` module
- Implemented a acknowledment list that stores incoming packets sequence numbers 
- Sending module can use this to get the acknowledgment that needs to be sent with the next packet.

Created `Acknowledgment` struct
- We should update to using this structure for the whole acknowledgment group instead of having them as different fields within the packet. This would improve structure of the code.