### PR TITLE
Packet Ordering

### DIFF
--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -18,8 +18,8 @@ use crate::packet::Packet;
 
 pub const WINDOW_SIZE: u8 = 20;
 
-pub fn needs_ack(p_type: &PType) -> bool {
-    match p_type {
+pub fn needs_ack(packet: &Packet) -> bool {
+    match packet.flags.p_type {
         PType::Data => true,
         PType::AckOnly => false,
         _ => false,

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -18,7 +18,7 @@ use crate::packet::Packet;
 
 pub const WINDOW_SIZE: u8 = 20;
 
-pub fn needs_retry(p_type: &PType) -> bool {
+pub fn needs_ack(p_type: &PType) -> bool {
     match p_type {
         PType::Data => true,
         PType::AckOnly => false,
@@ -82,7 +82,7 @@ impl Link {
         });
 
         // Create data strcuture for the receive thread
-        let recv_thread_data = ReceiveThread::new(
+        let mut recv_thread_data = ReceiveThread::new(
             self.socket.clone(),
             self.peer_addr,
             self.output_queue.clone(),

--- a/src/link/receivethread.rs
+++ b/src/link/receivethread.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::net::UdpSocket;
@@ -5,7 +6,46 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use crate::acknowledgment::{AcknowledgmentCheck, AcknowledgmentList};
+use crate::link::needs_ack;
+use crate::packet::PType;
 use crate::packet::Packet;
+
+pub struct OrderList {
+    seq: u32,
+    list: HashMap<u32, Packet>,
+}
+
+impl OrderList {
+    pub fn new(seq: u32) -> OrderList {
+        OrderList {
+            seq,
+            list: HashMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, packet: Packet) -> Result<Vec<Packet>, u8> {
+        if packet.sequence > self.seq + 1 {
+            self.list.insert(packet.sequence, packet);
+            Err(1)
+        } else if packet.sequence == self.seq + 1 {
+            let mut result = vec![packet];
+
+            self.seq += 1;
+
+            loop {
+                match self.list.remove(&(self.seq + 1)) {
+                    Some(n_packet) => {
+                        self.seq += 1;
+                        result.push(n_packet);
+                    }
+                    None => break Ok(result),
+                }
+            }
+        } else {
+            Err(0)
+        }
+    }
+}
 
 pub struct ReceiveThread {
     socket: Arc<UdpSocket>,
@@ -15,6 +55,8 @@ pub struct ReceiveThread {
 
     ack_list: Arc<Mutex<AcknowledgmentList>>,
     ack_check: Arc<Mutex<AcknowledgmentCheck>>,
+
+    order_list: OrderList,
 
     _recv_seq: Arc<Mutex<u32>>,
 }
@@ -29,6 +71,11 @@ impl ReceiveThread {
         ack_list: Arc<Mutex<AcknowledgmentList>>,
         recv_seq: Arc<Mutex<u32>>,
     ) -> ReceiveThread {
+        let recv_lock = recv_seq.lock().expect("Unable to lock recv_seq");
+        let seq = *recv_lock;
+
+        drop(recv_lock);
+
         ReceiveThread {
             socket,
             _peer_addr: peer_addr,
@@ -37,10 +84,11 @@ impl ReceiveThread {
             ack_check,
             ack_list,
             _recv_seq: recv_seq,
+            order_list: OrderList::new(seq),
         }
     }
 
-    pub fn start(&self) {
+    pub fn start(&mut self) {
         let mut buf = [0; 512];
         println!("Starting receive thread...");
         loop {
@@ -84,20 +132,45 @@ impl ReceiveThread {
     }
 
     fn send_ack(&self, packet: &Packet) {
-        let mut ack_lock = self.ack_list.lock().expect("Unable to lack ack list");
-        (*ack_lock).insert(packet.sequence);
+        if needs_ack(&packet.flags.p_type) {
+            let mut ack_lock = self.ack_list.lock().expect("Unable to lack ack list");
+            (*ack_lock).insert(packet.sequence);
+        }
     }
 
     fn recv_ack(&self, packet: &Packet) {
         let mut ack_lock = self.ack_check.lock().expect("unable to lock ack check");
-        //println!("Received: {:?}", packet.ack);
         (*ack_lock).acknowledge(packet.ack.clone());
     }
 
-    fn output(&self, packet: Packet) {
-        if !packet.payload.is_empty() {
-            let mut output_lock = self.output_queue.lock().expect("Cannot lock output queue");
-            (*output_lock).push_back(packet);
+    fn output(&mut self, packet: Packet) {
+        match packet.flags.p_type {
+            PType::AckOnly => (),
+            _ => self.order_output(packet),
+        }
+    }
+
+    fn order_output(&mut self, packet: Packet) {
+        //println!("{:?}", packet.sequence);
+        let mut output_lock = self.output_queue.lock().expect("Cannot lock output queue");
+        (*output_lock).push_back(packet);
+        return;
+        match self.order_list.insert(packet) {
+            Ok(mut packets) => loop {
+                println!("{:?}", packets);
+                match packets.pop() {
+                    Some(p) => {
+                        println!("{:?}", p);
+                        let mut output_lock =
+                            self.output_queue.lock().expect("Cannot lock output queue");
+                        (*output_lock).push_back(p);
+                    }
+                    None => break,
+                }
+            },
+            Err(1) => (),
+            Err(0) => panic!("Sequence number too old"),
+            _ => panic!("Unexpected error"),
         }
     }
 }

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -12,15 +12,15 @@ mod tests {
         let socket1 = UdpSocket::bind(("0.0.0.0", 8181)).unwrap();
         let socket2 = UdpSocket::bind(("0.0.0.0", 8282)).unwrap();
 
-        let mut link1 = Link::new(socket1, peer_addr2, 10, 1000);
-        let mut link2 = Link::new(socket2, peer_addr1, 1000, 10);
+        let mut link1 = Link::new(socket1, peer_addr2, 0, 1000);
+        let mut link2 = Link::new(socket2, peer_addr1, 1000, 0);
 
         link1.start();
         link2.start();
 
         let mut data: Vec<Vec<u8>> = Vec::new();
 
-        for i in 1..1000 {
+        for i in 1..1000000 {
             data.push(format!("Hello {}", i).as_bytes().to_vec());
         }
 

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -12,8 +12,8 @@ mod tests {
         let socket1 = UdpSocket::bind(("0.0.0.0", 8181)).unwrap();
         let socket2 = UdpSocket::bind(("0.0.0.0", 8282)).unwrap();
 
-        let mut link1 = Link::new(socket1, peer_addr2, 10, 10);
-        let mut link2 = Link::new(socket2, peer_addr1, 10, 10);
+        let mut link1 = Link::new(socket1, peer_addr2, 10, 1000);
+        let mut link2 = Link::new(socket2, peer_addr1, 1000, 10);
 
         link1.start();
         link2.start();

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -20,7 +20,7 @@ mod tests {
 
         let mut data: Vec<Vec<u8>> = Vec::new();
 
-        for i in 1..1000000 {
+        for i in 1..100 {
             data.push(format!("Hello {}", i).as_bytes().to_vec());
         }
 


### PR DESCRIPTION
Packets are now only added to the output queue by receiver thread in the correct order.

### Briefly How the `OrderList` works
For this ordering, we make use of a structure `OrderList`.
- When we insert a packet into this list, it would either
    - Output a list of packets in order (in form of a `VecDequeue<Packet>`) which could also contain a single packet which was inserted
    - Output `Err(1)` signifying that the current packet is not supposed to be the next expected packet
- When a packet is inserted which is the next expected packet, the `OrderList` would check if the next packet is already in the list and add that to the output as well and so on.
- For example if currently we have packets `10, 12, 13, 14, 15` and we insert packet 11 into the `OrderList`, the output would be a queue of packets `10, 11...15`