### PR TITLE
Tracker Packet and UDP Holepunching Handshake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,8 +7,9 @@ name = "aether_lib"
 version = "0.1.0"
 dependencies = [
  "clippy",
- "crossbeam",
  "rand",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -22,12 +23,6 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "autocfg"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
@@ -74,64 +69,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
-name = "crossbeam"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +112,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,19 +130,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
-name = "memoffset"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "rand"
@@ -271,10 +223,52 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.1.0"
+name = "ryu"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
+
+[[package]]
+name = "serde"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "term"
@@ -286,6 +280,12 @@ dependencies = [
  "dirs",
  "winapi",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ name = "aether_lib"
 path = "src/lib.rs"
 
 [dependencies]
-crossbeam = "0.8.1"
 rand = "0.8"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 clippy = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,6 @@
 pub mod acknowledgment;
 pub mod link;
 pub mod packet;
+pub mod peer;
 pub mod tracker;
 pub mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,5 @@
 pub mod acknowledgment;
 pub mod link;
 pub mod packet;
+pub mod tracker;
 pub mod util;

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -20,6 +20,8 @@ pub const WINDOW_SIZE: u8 = 20;
 pub const ACK_WAIT_TIME: u64 = 1000;
 pub const POLL_TIME_US: u64 = 100;
 pub const TIMEOUT: u64 = 10_000;
+pub const RETRY_DELAY: u64 = 1000;
+pub const MAX_RETRIES: i16 = 10;
 
 pub fn needs_ack(packet: &Packet) -> bool {
     match packet.flags.p_type {

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -17,6 +17,9 @@ use crate::packet::PType;
 use crate::packet::Packet;
 
 pub const WINDOW_SIZE: u8 = 20;
+pub const ACK_WAIT_TIME: u64 = 1000;
+pub const POLL_TIME_US: u64 = 100;
+pub const TIMEOUT: u64 = 10_000;
 
 pub fn needs_ack(packet: &Packet) -> bool {
     match packet.flags.p_type {
@@ -37,6 +40,7 @@ pub struct Link {
     send_seq: Arc<Mutex<u32>>,
     recv_seq: Arc<Mutex<u32>>,
     stop_flag: Arc<Mutex<bool>>,
+    batch_empty: Arc<Mutex<bool>>,
 }
 
 impl Link {
@@ -50,6 +54,7 @@ impl Link {
         let output_queue = Arc::new(Mutex::new(VecDeque::new()));
 
         let stop_flag = Arc::new(Mutex::new(false));
+        let batch_empty = Arc::new(Mutex::new(false));
         Link {
             ack_list: Arc::new(Mutex::new(AcknowledgmentList::new(recv_seq))),
             ack_check: Arc::new(Mutex::new(AcknowledgmentCheck::new(send_seq))),
@@ -61,6 +66,7 @@ impl Link {
             recv_seq: Arc::new(Mutex::new(recv_seq)),
             thread_handles: Vec::new(),
             stop_flag,
+            batch_empty,
         }
     }
 
@@ -74,6 +80,7 @@ impl Link {
             self.ack_check.clone(),
             self.ack_list.clone(),
             self.send_seq.clone(),
+            self.batch_empty.clone(),
         );
 
         // Start the send thread
@@ -146,21 +153,49 @@ impl Link {
     }
 
     pub fn recv(&mut self) -> Result<Vec<u8>, u8> {
-        // Pop the next packet from output queue
+        let flag_lock = self.stop_flag.lock().expect("Error locking stop flag");
+        let stop = *flag_lock;
+        drop(flag_lock);
+
+        if stop {
+            Err(255)
+        } else {
+            // Pop the next packet from output queue
+            loop {
+                let mut queue_lock = self.output_queue.lock().expect("Cannot lock output queue");
+
+                let result = queue_lock.pop_front();
+
+                drop(queue_lock);
+
+                // Get payload out of the packet and return
+                match result {
+                    Some(packet) => break Ok(packet.payload),
+                    None => {
+                        thread::sleep(Duration::from_micros(POLL_TIME_US));
+                    }
+                };
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        let queue_lock = self.output_queue.lock().expect("Cannot lock output queue");
+        let result = (*queue_lock).is_empty();
+        drop(queue_lock);
+
+        let batch_lock = self.batch_empty.lock().expect("Cannot lock batch queue");
+
+        result && (*batch_lock)
+    }
+
+    pub fn wait(&self) {
         loop {
-            let mut queue_lock = self.output_queue.lock().expect("Cannot lock output queue");
-
-            let result = queue_lock.pop_front();
-
-            drop(queue_lock);
-
-            // Get payload out of the packet and return
-            match result {
-                Some(packet) => break Ok(packet.payload),
-                None => {
-                    thread::sleep(Duration::from_micros(100));
-                }
-            };
+            if self.is_empty() {
+                thread::sleep(Duration::from_millis(ACK_WAIT_TIME));
+                break;
+            }
+            thread::sleep(Duration::from_micros(POLL_TIME_US));
         }
     }
 }

--- a/src/link/sendthread.rs
+++ b/src/link/sendthread.rs
@@ -3,11 +3,16 @@ use std::net::SocketAddr;
 use std::net::UdpSocket;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
 
 use crate::acknowledgment::{AcknowledgmentCheck, AcknowledgmentList};
+use crate::link::MAX_RETRIES;
+use crate::link::RETRY_DELAY;
 use crate::link::{needs_ack, WINDOW_SIZE};
 use crate::packet::PType;
 use crate::packet::Packet;
+use crate::packet::PacketMeta;
 
 pub struct SendThread {
     batch_queue: VecDeque<Packet>,
@@ -61,23 +66,66 @@ impl SendThread {
 
             match self.batch_queue.pop_front() {
                 Some(mut packet) => {
-                    if !self.check_ack(&packet) {
-                        self.add_ack(&mut packet);
-                        self.send(packet);
+                    if packet.is_meta {
+                        if !self.batch_queue.is_empty() {
+                            // If this is a meta packet check if it requires a delay
+                            if packet.meta.delay_ms > 0 {
+                                thread::sleep(Duration::from_millis(packet.meta.delay_ms));
+                            }
+
+                            // Increase retry count since after this same packets
+                            // will be sent again
+                            let retry_count = packet.meta.retry_count + 1;
+
+                            if retry_count >= MAX_RETRIES {
+                                // Stop connection if too many retries
+                                let mut flag_lock =
+                                    self.stop_flag.lock().expect("Error locking stop flag");
+                                *flag_lock = true;
+                            } else {
+                                let mut meta_packet = Packet::new(PType::Extended, 0);
+
+                                meta_packet.set_meta(PacketMeta {
+                                    retry_count,
+                                    delay_ms: RETRY_DELAY,
+                                });
+
+                                self.batch_queue.push_back(meta_packet);
+                            }
+                        }
+                    } else {
+                        if !self.check_ack(&packet) {
+                            self.add_ack(&mut packet);
+                            self.send(packet);
+                        }
                     }
                 }
                 None => {
                     self.fetch_window();
                     let mut empty_lock = self.is_empty.lock().expect("Unable to lock empty bool");
 
+                    let mut retry_delay = 0;
                     // If still empty
                     if self.batch_queue.is_empty() {
                         (*empty_lock) = true;
                         // Send a ack only packet (with empty payload)
                         self.batch_queue.push_back(self.ack_packet());
+                        retry_delay = RETRY_DELAY;
                     } else {
                         (*empty_lock) = false;
                     }
+
+                    // At end of each window push a meta packet
+                    // This is to keep track of number of retries
+                    let mut meta_packet = Packet::new(PType::Extended, 0);
+
+                    // Retry count here is -1 so after trying once it is set to 0
+                    meta_packet.set_meta(PacketMeta {
+                        retry_count: -1,
+                        delay_ms: retry_delay,
+                    });
+
+                    self.batch_queue.push_back(meta_packet);
 
                     drop(empty_lock);
                 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -220,15 +220,6 @@ impl From<Vec<u8>> for Packet {
     }
 }
 
-pub struct TrackerPacket {
-    _username: String,
-    _id_num: u32,
-    _req: bool,
-    _packet_type: u8,
-    _port: u16,
-    _ip: [u8; 4],
-}
-
 #[cfg(test)]
 mod tests {
     use crate::packet::PType;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -9,6 +9,7 @@ use std::vec::Vec;
 pub enum PType {
     Data,
     AckOnly,
+    Initiation,
     Extended,
 }
 
@@ -17,6 +18,7 @@ impl From<PType> for u8 {
         match p_type {
             PType::Data => 0,
             PType::AckOnly => 1,
+            PType::Initiation => 2,
             PType::Extended => 15,
         }
     }
@@ -27,6 +29,7 @@ impl From<u8> for PType {
         match Option::from(p_type) {
             Some(0) => PType::Data,
             Some(1) => PType::AckOnly,
+            Some(2) => PType::Initiation,
             _ => PType::Extended,
         }
     }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -63,11 +63,19 @@ impl PacketFlags {
 }
 
 #[derive(Debug)]
+pub struct PacketMeta {
+    pub delay_ms: u64,
+    pub retry_count: i16,
+}
+
+#[derive(Debug)]
 pub struct Packet {
     pub flags: PacketFlags,
     pub sequence: u32,
     pub ack: Acknowledgment,
     pub payload: Vec<u8>,
+    pub is_meta: bool,
+    pub meta: PacketMeta,
 }
 
 impl Packet {
@@ -92,8 +100,19 @@ impl Packet {
                 miss: Vec::new(),
             },
             payload: Vec::new(),
+            is_meta: false,
+            meta: PacketMeta {
+                delay_ms: 0,
+                retry_count: 0,
+            },
         }
     }
+
+    pub fn set_meta(&mut self, meta: PacketMeta) {
+        self.is_meta = true;
+        self.meta = meta;
+    }
+
     /// Add ack struct into the packet
     ///
     /// # Arguments
@@ -186,6 +205,11 @@ impl From<Vec<u8>> for Packet {
                 miss: Vec::new(),
             },
             payload: Vec::new(),
+            is_meta: false,
+            meta: PacketMeta {
+                delay_ms: 0,
+                retry_count: 0,
+            },
         };
 
         // Packet ID converting u8 to u32(vector)

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -1,0 +1,111 @@
+use std::{
+    net::{SocketAddr, UdpSocket},
+    time::Duration,
+};
+
+use crate::{acknowledgment::Acknowledgment, packet::Packet};
+use crate::{link::Link, packet::PType};
+
+use rand::{thread_rng, Rng};
+
+const INITIATE_DELAY: u64 = 500;
+
+pub fn handshake(
+    socket: UdpSocket,
+    address: SocketAddr,
+    my_username: String,
+    peer_username: String,
+) -> Link {
+    let seq = thread_rng().gen_range(0..(1 << 16 as u32)) as u32;
+    let recv_seq: u32;
+
+    println!("Seq: {}", seq);
+
+    let ack: bool;
+
+    socket
+        .set_read_timeout(Some(Duration::from_millis(INITIATE_DELAY)))
+        .expect("Unable to set read timeout");
+
+    let mut packet = Packet::new(PType::Initiation, seq);
+    packet.append_payload(my_username.clone().into_bytes());
+
+    let sequence_data = packet.compile();
+
+    // Repeat sending start sequence number and ID
+    loop {
+        socket
+            .send_to(&sequence_data, address)
+            .expect("Couldn't send sequence");
+
+        let mut buf: [u8; 1024] = [0; 1024];
+
+        match socket.recv(&mut buf) {
+            Ok(size) => {
+                if size > 0 {
+                    let recved = Packet::from(buf[..size].to_vec());
+                    let username_recved =
+                        String::from_utf8(recved.payload.clone()).expect("Unable to get username");
+
+                    // Verify the sender has the correct username
+                    if username_recved == peer_username {
+                        recv_seq = recved.sequence;
+
+                        ack = recved.flags.ack && recved.ack.ack_begin == seq;
+
+                        break;
+                    }
+                }
+            }
+            _ => (),
+        }
+    }
+
+    // If not acknowledged by other peer yet
+    if !ack {
+        packet.add_ack(Acknowledgment {
+            ack_begin: recv_seq,
+            ack_end: 0,
+            miss_count: 0,
+            miss: Vec::new(),
+        });
+
+        let ack_data = packet.compile();
+
+        // Repeat sending start sequence number, acknowledgement and ID
+        loop {
+            socket
+                .send_to(&ack_data, address)
+                .expect("Couldn't send sequence");
+
+            let mut buf: [u8; 1024] = [0; 1024];
+
+            match socket.recv(&mut buf) {
+                Ok(size) => {
+                    if size > 0 {
+                        let recved = Packet::from(buf[..size].to_vec());
+                        let username_recved = String::from_utf8(recved.payload.clone())
+                            .expect("Unable to get username");
+
+                        // Verify the sender has the correct username
+                        if username_recved == peer_username && recved.sequence == recv_seq {
+                            if recved.flags.ack && recved.ack.ack_begin == seq {
+                                break;
+                            }
+                        }
+                    }
+                }
+                _ => (),
+            }
+        }
+    }
+
+    println!("Handhskae done {}", seq);
+
+    // Start the link
+    let mut link = Link::new(socket, address.clone(), seq, recv_seq);
+
+    link.start();
+
+    link
+}

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -42,7 +42,7 @@ pub fn handshake(
 
         match socket.recv(&mut buf) {
             Ok(size) => {
-                if size > 0 {
+                if thread_rng().gen_range(0..100) > 20 && size > 0 {
                     let recved = Packet::from(buf[..size].to_vec());
                     let username_recved =
                         String::from_utf8(recved.payload.clone()).expect("Unable to get username");
@@ -60,6 +60,8 @@ pub fn handshake(
             _ => (),
         }
     }
+
+    println!("{}: stage 1 complete", my_username);
 
     // If not acknowledged by other peer yet
     if !ack {
@@ -79,10 +81,12 @@ pub fn handshake(
                 .expect("Couldn't send sequence");
 
             let mut buf: [u8; 1024] = [0; 1024];
-
+            if thread_rng().gen_range(0..100) < 99 {
+                continue;
+            }
             match socket.recv(&mut buf) {
                 Ok(size) => {
-                    if size > 0 {
+                    if thread_rng().gen_range(0..100) > 20 && size > 0 {
                         let recved = Packet::from(buf[..size].to_vec());
                         let username_recved = String::from_utf8(recved.payload.clone())
                             .expect("Unable to get username");
@@ -100,7 +104,8 @@ pub fn handshake(
         }
     }
 
-    println!("Handhskae done {}", seq);
+    println!("{}: stage 2 complete", my_username);
+    println!("Handshake done {}", seq);
 
     // Start the link
     let mut link = Link::new(socket, address.clone(), seq, recv_seq);

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -34,3 +34,28 @@ impl TryFrom<Vec<u8>> for TrackerPacket {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use crate::tracker::TrackerPacket;
+    use serde::{Deserialize, Serialize};
+    use std::convert::TryFrom;
+    #[test]
+    fn tracker_test() {
+        let mut packet = TrackerPacket {
+            username: "test".to_string(),
+            req: true,
+            packet_type: 10 as u8,
+            port: 1234,
+            ip: [1, 2, 3, 4],
+        };
+        let parsed_packet: Vec<u8> = TryFrom::try_from(packet).unwrap();
+        let unparsed_packet: TrackerPacket = TryFrom::try_from(parsed_packet).unwrap();
+        assert_eq!("test".to_string(), unparsed_packet.username);
+        assert_eq!(true, unparsed_packet.req);
+        assert_eq!(10, unparsed_packet.packet_type);
+        assert_eq!(1234, unparsed_packet.port);
+        assert_eq!([1, 2, 3, 4], unparsed_packet.ip);
+    }
+}

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -2,12 +2,23 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
 #[derive(Serialize, Deserialize)]
-pub struct TrackerPacket {
+pub struct ConnectionRequest {
+    pub identity_number: u32,
     pub username: String,
+    pub port: u16,
+    pub ip: [u8; 4],
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TrackerPacket {
+    pub identity_number: u32,
+    pub username: String,
+    pub peer_username: String,
     pub req: bool,
     pub packet_type: u8,
     pub port: u16,
     pub ip: [u8; 4],
+    pub connections: Vec<ConnectionRequest>,
 }
 
 impl TryFrom<TrackerPacket> for Vec<u8> {
@@ -43,7 +54,10 @@ mod tests {
     use std::convert::TryFrom;
     #[test]
     fn tracker_test() {
-        let mut packet = TrackerPacket {
+        let packet = TrackerPacket {
+            identity_number: 42,
+            peer_username: "another".to_string(),
+            connections: Vec::new(),
             username: "test".to_string(),
             req: true,
             packet_type: 10 as u8,
@@ -53,6 +67,9 @@ mod tests {
         let parsed_packet: Vec<u8> = TryFrom::try_from(packet).unwrap();
         let unparsed_packet: TrackerPacket = TryFrom::try_from(parsed_packet).unwrap();
         assert_eq!("test".to_string(), unparsed_packet.username);
+        assert_eq!("another".to_string(), unparsed_packet.peer_username);
+        assert!(unparsed_packet.connections.is_empty());
+        assert_eq!(42, unparsed_packet.identity_number);
         assert_eq!(true, unparsed_packet.req);
         assert_eq!(10, unparsed_packet.packet_type);
         assert_eq!(1234, unparsed_packet.port);

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+
+#[derive(Serialize, Deserialize)]
+pub struct TrackerPacket {
+    pub username: String,
+    pub req: bool,
+    pub packet_type: u8,
+    pub port: u16,
+    pub ip: [u8; 4],
+}
+
+impl TryFrom<TrackerPacket> for Vec<u8> {
+    type Error = &'static str;
+
+    fn try_from(packet: TrackerPacket) -> Result<Self, Self::Error> {
+        match serde_json::to_string(&packet) {
+            Ok(json) => Ok(json.into_bytes()),
+            Err(_) => Err("Error converting to json"),
+        }
+    }
+}
+
+impl TryFrom<Vec<u8>> for TrackerPacket {
+    type Error = &'static str;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        match String::from_utf8(bytes) {
+            Ok(json) => match serde_json::from_str(&json) {
+                Ok(data) => Ok(data),
+                Err(_) => Err("Unable to parse json"),
+            },
+            Err(_) => Err("Unable to parse utf8"),
+        }
+    }
+}

--- a/src/tracker.rs
+++ b/src/tracker.rs
@@ -9,6 +9,17 @@ pub struct ConnectionRequest {
     pub ip: [u8; 4],
 }
 
+impl Clone for ConnectionRequest {
+    fn clone(&self) -> Self {
+        ConnectionRequest {
+            identity_number: self.identity_number,
+            username: self.username.clone(),
+            port: self.port,
+            ip: self.ip.clone(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct TrackerPacket {
     pub identity_number: u32,

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use std::net::UdpSocket;
+    use std::net::{IpAddr, Ipv4Addr, UdpSocket};
     use std::thread;
     use std::time::Duration;
 
@@ -11,11 +11,16 @@ mod tests {
         let socket1 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
         let socket2 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
 
-        let peer_addr1 = socket1.local_addr().unwrap();
-        let peer_addr2 = socket2.local_addr().unwrap();
+        let mut peer_addr1 = socket1.local_addr().unwrap();
+        let mut peer_addr2 = socket2.local_addr().unwrap();
+
+        peer_addr1.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+        peer_addr2.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
 
         let mut link1 = Link::new(socket1, peer_addr2, 0, 1000);
         let mut link2 = Link::new(socket2, peer_addr1, 1000, 0);
+
+        println!("{:?} {:?}", peer_addr1, peer_addr2);
 
         link1.start();
         link2.start();
@@ -58,9 +63,13 @@ mod tests {
         let socket1 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
         let socket2 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
 
-        let peer_addr1 = socket1.local_addr().unwrap();
-        let peer_addr2 = socket2.local_addr().unwrap();
+        let mut peer_addr1 = socket1.local_addr().unwrap();
+        let mut peer_addr2 = socket2.local_addr().unwrap();
 
+        peer_addr1.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+        peer_addr2.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+
+        println!("{:?} {:?}", peer_addr1, peer_addr2);
         let len = 100;
 
         let send_thread = thread::spawn(move || {
@@ -69,7 +78,8 @@ mod tests {
                 peer_addr2,
                 String::from("peer1"),
                 String::from("peer2"),
-            );
+            )
+            .expect("Handshake failed");
 
             let mut data: Vec<Vec<u8>> = Vec::new();
 
@@ -93,7 +103,8 @@ mod tests {
                 peer_addr1,
                 String::from("peer2"),
                 String::from("peer1"),
-            );
+            )
+            .expect("Handshake failed");
 
             let mut count = 0;
             let mut recv: Vec<Vec<u8>> = Vec::new();

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -1,16 +1,18 @@
 #[cfg(test)]
 mod tests {
-    use std::net::{SocketAddr, UdpSocket};
-    use std::str::FromStr;
+    use std::net::UdpSocket;
+    use std::thread;
+    use std::time::Duration;
 
     use aether_lib::link::Link;
+    use aether_lib::peer::handshake;
     #[test]
     pub fn link_test() {
-        let peer_addr1 = SocketAddr::from_str("127.0.0.1:8181").unwrap();
-        let peer_addr2 = SocketAddr::from_str("127.0.0.1:8282").unwrap();
+        let socket1 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
+        let socket2 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
 
-        let socket1 = UdpSocket::bind(("0.0.0.0", 8181)).unwrap();
-        let socket2 = UdpSocket::bind(("0.0.0.0", 8282)).unwrap();
+        let peer_addr1 = socket1.local_addr().unwrap();
+        let peer_addr2 = socket2.local_addr().unwrap();
 
         let mut link1 = Link::new(socket1, peer_addr2, 0, 1000);
         let mut link2 = Link::new(socket2, peer_addr1, 1000, 0);
@@ -39,6 +41,81 @@ mod tests {
                 }
             }
         }
+
+        for i in 0..recv.len() {
+            let a = String::from_utf8(recv[i].clone()).unwrap();
+            let b = String::from_utf8(data[i].clone()).unwrap();
+            println!("{} == {}", a, b);
+            assert_eq!(recv[i], data[i]);
+        }
+
+        println!("Stopping");
+    }
+
+    #[test]
+    pub fn handshake_test() {
+        let socket1 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
+        let socket2 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
+
+        let peer_addr1 = socket1.local_addr().unwrap();
+        let peer_addr2 = socket2.local_addr().unwrap();
+
+        let len = 100;
+
+        let send_thread = thread::spawn(move || {
+            let mut link = handshake(
+                socket1,
+                peer_addr2,
+                String::from("peer1"),
+                String::from("peer2"),
+            );
+
+            let mut data: Vec<Vec<u8>> = Vec::new();
+
+            for i in 0..len {
+                data.push(format!("Hello {}", i).as_bytes().to_vec());
+            }
+
+            for x in &data {
+                link.send(x.clone());
+            }
+
+            link.wait();
+            println!("Stopping sender");
+
+            data
+        });
+
+        let recv_thread = thread::spawn(move || {
+            let mut link = handshake(
+                socket2,
+                peer_addr1,
+                String::from("peer2"),
+                String::from("peer1"),
+            );
+
+            let mut count = 0;
+            let mut recv: Vec<Vec<u8>> = Vec::new();
+            loop {
+                match link.recv() {
+                    Ok(recved_data) => {
+                        count += 1;
+                        recv.push(recved_data);
+                        if count >= len {
+                            break;
+                        }
+                    }
+                    Err(255) => panic!("Connection closed"),
+                    Err(_) => panic!("Unexpected error while receiving"),
+                }
+            }
+
+            println!("Stopping receiver");
+            recv
+        });
+
+        let data = send_thread.join().expect("Send thread panicked");
+        let recv = recv_thread.join().expect("Receive thread panicked");
 
         for i in 0..recv.len() {
             let a = String::from_utf8(recv[i].clone()).unwrap();

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -58,7 +58,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     pub fn handshake_test() {
         let socket1 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
         let socket2 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -58,6 +58,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     pub fn handshake_test() {
         let socket1 = UdpSocket::bind(("0.0.0.0", 10100)).unwrap();
         let socket2 = UdpSocket::bind(("0.0.0.0", 10101)).unwrap();

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -53,6 +53,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     pub fn handshake_test() {
         let socket1 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
         let socket2 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, UdpSocket};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
     use std::thread;
     use std::time::Duration;
 
@@ -59,16 +59,20 @@ mod tests {
 
     #[test]
     pub fn handshake_test() {
-        let socket1 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
-        let socket2 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
+        let socket1 = UdpSocket::bind(("0.0.0.0", 10100)).unwrap();
+        let socket2 = UdpSocket::bind(("0.0.0.0", 10101)).unwrap();
 
-        let mut peer_addr1 = socket1.local_addr().unwrap();
-        let mut peer_addr2 = socket2.local_addr().unwrap();
-
-        peer_addr1.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
-        peer_addr2.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+        let peer_addr1 = SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            socket1.local_addr().unwrap().port(),
+        );
+        let peer_addr2 = SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+            socket2.local_addr().unwrap().port(),
+        );
 
         println!("{:?} {:?}", peer_addr1, peer_addr2);
+
         let len = 100;
 
         let send_thread = thread::spawn(move || {


### PR DESCRIPTION
Migrated Tracker Packet to `aether_lib`.

Implemented a handshake for UDP Holepunching as mentioned in the [diagram](https://github.com/Prototype-Aether/Prototype-Aether/blob/main/Software-Architecture.drawio). It is a 3 way handshake a little similar to how TCP handhshakes work.

From here, we should use this as follows
- If this handshake fails (times out), we should retry the connection by again asking the tracker server for public identity again
- If this handshake is successful on either end, We would send a confirmation using link module. If this confirmation doesn't again work, we assume the link failed and try again
- If the confirmation is successful, we have a working reliable link.