### PR TITLE
Added an Error Structure to represent errors within `aether_lib`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,28 @@
+pub struct AetherError {
+    pub code: u16,
+    pub description: String,
+    pub cause: Option<Box<AetherError>>,
+}
+
+impl AetherError {
+    pub fn traceback(&self) -> String {
+        let mut result: String = String::new();
+
+        result = result
+            + &format!(
+                "Error code: {}\n{}\nCaused by -\n",
+                self.code, self.description
+            );
+
+        match self.cause {
+            Some(ref error) => result += &error.traceback(),
+            None => (),
+        }
+
+        result
+    }
+
+    pub fn print(&self) {
+        println!("Traceback:\n{}", self.traceback());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! A library that provides P2P communication for Prototype Aether.
 
 pub mod acknowledgement;
+pub mod error;
 pub mod link;
 pub mod packet;
 pub mod peer;

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -132,7 +132,7 @@ impl Link {
         } {}
     }
 
-    pub fn send(&mut self, buf: Vec<u8>) {
+    pub fn send(&self, buf: Vec<u8>) {
         // Lock seq number
         let mut seq_lock = self.send_seq.lock().expect("Unable to lock seq");
         // Increase sequence number
@@ -161,7 +161,7 @@ impl Link {
         self.read_timeout = Some(timeout);
     }
 
-    pub fn recv_timeout(&mut self, timeout: Duration) -> Result<Vec<u8>, u8> {
+    pub fn recv_timeout(&self, timeout: Duration) -> Result<Vec<u8>, u8> {
         let flag_lock = self.stop_flag.lock().expect("Error locking stop flag");
         let stop = *flag_lock;
         drop(flag_lock);
@@ -195,7 +195,7 @@ impl Link {
         }
     }
 
-    pub fn recv(&mut self) -> Result<Vec<u8>, u8> {
+    pub fn recv(&self) -> Result<Vec<u8>, u8> {
         let flag_lock = self.stop_flag.lock().expect("Error locking stop flag");
         let stop = *flag_lock;
         drop(flag_lock);

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -334,7 +334,7 @@ impl Aether {
                                     );
 
                                     match link_result {
-                                        Ok(mut link) => {
+                                        Ok(link) => {
                                             println!("Handshake success");
                                             link.send(username.clone().into_bytes());
                                             let delay = thread_rng().gen_range(0..DELTA_TIME);

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -77,7 +77,7 @@ mod tests {
         let len = 100;
 
         let send_thread = thread::spawn(move || {
-            let mut link = handshake(
+            let link = handshake(
                 socket1,
                 peer_addr2,
                 String::from("peer1"),
@@ -102,7 +102,7 @@ mod tests {
         });
 
         let recv_thread = thread::spawn(move || {
-            let mut link = handshake(
+            let link = handshake(
                 socket2,
                 peer_addr1,
                 String::from("peer2"),


### PR DESCRIPTION
Added a structure to represent errors in `aether_lib`. We should now add `Result<..., AetherError>` return types to functions which can encounter errors. Also added functions to get and print a trace back from `AetherError`.

Next step would be to start working on error handling once we have added this to base level functions.

Few minor fixes - removing mutable references where not needed