### PR TITLE
Reorganize connection request

### DIFF
--- a/src/peer/handshake.rs
+++ b/src/peer/handshake.rs
@@ -22,8 +22,6 @@ pub fn handshake(
 
     let ack: bool;
 
-    //println!("Handshake {} {:?} to {:?}", my_username, socket, address);
-
     socket
         .set_read_timeout(Some(Duration::from_millis(INITIATE_DELAY)))
         .expect("Unable to set read timeout");

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -12,7 +12,6 @@ use std::net::{IpAddr, Ipv4Addr, UdpSocket};
 
 use rand::{thread_rng, Rng};
 
-use crate::link::POLL_TIME_US;
 use crate::tracker::TrackerPacket;
 use crate::{link::Link, tracker::ConnectionRequest};
 
@@ -23,6 +22,7 @@ pub const SERVER_POLL_TIME: u64 = 1000;
 pub const HANDSHAKE_RETRY_DELAY: u64 = 5000;
 pub const CONNECTION_CHECK_DELAY: u64 = 1000;
 pub const DELTA_TIME: u64 = 100;
+pub const POLL_TIME_US: u64 = 100;
 
 pub struct Peer {
     pub username: String,

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -24,7 +24,6 @@ pub const CONNECTION_CHECK_DELAY: u64 = 1000;
 pub const DELTA_TIME: u64 = 100;
 pub const POLL_TIME_US: u64 = 100;
 
-#[derive(Debug)]
 pub enum Connection {
     Init(Initialized),
     Handshake,
@@ -32,7 +31,6 @@ pub enum Connection {
     Failed(Failure),
 }
 
-#[derive(Debug)]
 pub struct Peer {
     pub username: String,
     pub ip: [u8; 4],

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -94,6 +94,7 @@ impl Aether {
 
     pub fn start(&self) {
         println!("Starting aether service...");
+        println!("Failure fix");
         self.connection_poll();
         self.handle_sockets();
         self.handle_requests();


### PR DESCRIPTION
Rewrote connection lists -
- Instead of having multiple lists for initialized, in progress, failed and connected connections, it is better to have a single list which can be in an of these states
- Connection to every peer can only be in one of these states
- This makes the code way simpler and reduces the number of writes to be done to memory

Moved handling of connection request -
- Moved handling of connection request to a separate function to make the code more readable