### PR TITLE
Implemented `Display` and `Debug` for `AetherError`

### DIFF
--- a/src/acknowledgement.rs
+++ b/src/acknowledgement.rs
@@ -384,7 +384,6 @@ mod tests {
 
         #[test]
         fn check_complete_test() {
-            println!("\n\nIs complete test\n\n");
             let sequence = 10;
             let mut ack_list = AcknowledgementList::new(sequence);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Debug, Display, Formatter, Result};
+
 pub struct AetherError {
     pub code: u16,
     pub description: String,
@@ -24,5 +26,63 @@ impl AetherError {
 
     pub fn print(&self) {
         println!("Traceback:\n{}", self.traceback());
+    }
+}
+
+impl Display for AetherError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "E{}: {}", self.code, self.description)
+    }
+}
+
+impl Debug for AetherError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self.cause {
+            Some(ref error) => {
+                write!(f, "{}\nCause: {:?}", self, *error)
+            }
+            None => {
+                write!(f, "{}", self)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::error::AetherError;
+
+    #[test]
+    fn display_test() {
+        let err = AetherError {
+            code: 9001,
+            description: String::from("Test error"),
+            cause: None,
+        };
+
+        assert_eq!(format!("{}", err), "E9001: Test error");
+    }
+
+    #[test]
+
+    fn debug_test() {
+        let err1 = AetherError {
+            code: 9002,
+            description: String::from("Bottom level error"),
+            cause: None,
+        };
+        let err2 = AetherError {
+            code: 9023,
+            description: String::from("Middle level error"),
+            cause: Some(Box::new(err1)),
+        };
+        let err3 = AetherError {
+            code: 9032,
+            description: String::from("Top level error"),
+            cause: Some(Box::new(err2)),
+        };
+
+        assert_eq!(format!("{:?}", err3), 
+            "E9032: Top level error\nCause: E9023: Middle level error\nCause: E9002: Bottom level error");
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,29 +6,6 @@ pub struct AetherError {
     pub cause: Option<Box<AetherError>>,
 }
 
-impl AetherError {
-    pub fn traceback(&self) -> String {
-        let mut result: String = String::new();
-
-        result = result
-            + &format!(
-                "Error code: {}\n{}\nCaused by -\n",
-                self.code, self.description
-            );
-
-        match self.cause {
-            Some(ref error) => result += &error.traceback(),
-            None => (),
-        }
-
-        result
-    }
-
-    pub fn print(&self) {
-        println!("Traceback:\n{}", self.traceback());
-    }
-}
-
 impl Display for AetherError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "E{}: {}", self.code, self.description)


### PR DESCRIPTION
Implemented the Display and Debug traits for AetherError to make it easier to print the error as well as add traceback.