### PR TITLE
Reperesent Constants in a Configuration Structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -23,6 +24,12 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
@@ -112,6 +119,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +151,12 @@ name = "libc"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "ppv-lite86"
@@ -260,6 +289,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,3 +361,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,8 @@ name = "aether_lib"
 version = "0.1.0"
 dependencies = [
  "clippy",
+ "home",
+ "log",
  "rand",
  "serde",
  "serde_json",
@@ -125,6 +127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +168,15 @@ name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "ppv-lite86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.8"
 
 [dev-dependencies]
 clippy = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8"
+home = "0.5"
+log = "0.4"
 
 [dev-dependencies]
 clippy = "*"

--- a/src/acknowledgement.rs
+++ b/src/acknowledgement.rs
@@ -1,3 +1,5 @@
+//! Structures for facilitating storing acknowledgment numbers for verification and
+//! sending
 use std::collections::HashMap;
 
 /// Structure to reperesent the Acknowledgement format

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Serialize};
+use std::default::Default;
+
+/// Structure to represent configuration options for `aether_lib`
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct Config {
+    pub aether: AetherConfig,
+}
+
+/// Structure to represent configuration for [`Aether`][crate::peer::Aether]
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub struct AetherConfig {
+    /// Duration to wait for Tracker server to respond (in ms)
+    pub server_retry_delay: u64,
+    /// How often to poll server for new connections
+    pub server_poll_time: u64,
+    /// How long to wait to retry handshake after a failed attempt
+    /// Also used as duration to wait to receive nonce from other peer during
+    /// authentication
+    pub handshake_retry_delay: u64,
+    /// Poll time to check if connection has been established
+    pub connection_check_delay: u64,
+    /// Magnitude by which to randomize retry delay
+    pub delta_time: u64,
+    /// General poll time to be used to check for updates to lists shared by threads
+    /// (in us)
+    pub poll_time_us: u64,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            aether: Default::default(),
+        }
+    }
+}
+
+impl Default for AetherConfig {
+    fn default() -> Self {
+        Self {
+            server_retry_delay: 1000,
+            server_poll_time: 1000,
+            handshake_retry_delay: 5000,
+            connection_check_delay: 1000,
+            delta_time: 100,
+            poll_time_us: 100,
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,11 +20,15 @@ use crate::error::AetherError;
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
 #[serde(default)]
 pub struct Config {
+    /// Configuration for [`peer`][crate::peer] module
     pub aether: AetherConfig,
+    /// Configuration for [`handshake`][crate::peer::handshake] module
     pub handshake: HandshakeConfig,
+    /// Configuration for [`link`][crate::link] module
+    pub link: LinkConfig,
 }
 
-/// Structure to represent configuration for [`Aether`][crate::peer::Aether]
+/// Structure to represent configuration for [`peer`][crate::peer] module
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
 #[serde(default)]
 pub struct AetherConfig {
@@ -45,8 +49,7 @@ pub struct AetherConfig {
     pub poll_time_us: u64,
 }
 
-/// Structure to represent configuration for [`handshake`][crate::peer::handshake::handshake]
-/// function
+/// Structure to represent configuration for [`handshake`][crate::peer::handshake] module
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
 #[serde(default)]
 pub struct HandshakeConfig {
@@ -56,6 +59,24 @@ pub struct HandshakeConfig {
     pub peer_poll_time: u64,
     /// Timeout after which handshake can be declared failed if not complete (in ms)
     pub handshake_timeout: u64,
+}
+
+/// Structure to represent configuration for [`link`][crate::link] module
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
+#[serde(default)]
+pub struct LinkConfig {
+    /// Window size for the link. Determines how many packets are sent in a single burst
+    pub window_size: u8,
+    /// Time to wait for acknowledgement to be received
+    pub ack_wait_time: u64,
+    /// Poll time for shared memory structures
+    pub poll_time_us: u64,
+    /// Timeout or time of inactivity after which link is declared as broken
+    pub timeout: u64,
+    /// Time to wait for acknowledgment before sending packets again
+    pub retry_delay: u64,
+    /// Number of times a packet can be retried before link is declared as broken
+    pub max_retries: i16,
 }
 
 impl Config {
@@ -155,8 +176,9 @@ impl TryFrom<Config> for String {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            aether: Default::default(),
-            handshake: Default::default(),
+            aether: AetherConfig::default(),
+            handshake: HandshakeConfig::default(),
+            link: LinkConfig::default(),
         }
     }
 }
@@ -181,6 +203,20 @@ impl Default for HandshakeConfig {
         Self {
             peer_poll_time: 500,
             handshake_timeout: 5_000,
+        }
+    }
+}
+
+/// Default values for ['LinkConfig`]
+impl Default for LinkConfig {
+    fn default() -> Self {
+        Self {
+            window_size: 20,
+            ack_wait_time: 1_000,
+            poll_time_us: 100,
+            timeout: 10_000,
+            retry_delay: 100,
+            max_retries: 10,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,14 +1,16 @@
 use serde::{Deserialize, Serialize};
-use std::default::Default;
+use std::{convert::TryFrom, default::Default, fs, path::Path};
+
+use crate::error::AetherError;
 
 /// Structure to represent configuration options for `aether_lib`
-#[derive(Serialize, Deserialize, Clone, Copy)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
 pub struct Config {
     pub aether: AetherConfig,
 }
 
 /// Structure to represent configuration for [`Aether`][crate::peer::Aether]
-#[derive(Serialize, Deserialize, Clone, Copy)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
 pub struct AetherConfig {
     /// Duration to wait for Tracker server to respond (in ms)
     pub server_retry_delay: u64,
@@ -25,6 +27,100 @@ pub struct AetherConfig {
     /// General poll time to be used to check for updates to lists shared by threads
     /// (in us)
     pub poll_time_us: u64,
+}
+
+impl Config {
+    /// Returns configuration read from `file_path`
+    /// Configuration file must be in [YAML](https://yaml.org/) format
+    /// This may return an [`AetherError`] if the file is not present or if the file
+    /// is not correctly formated as yaml
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use aether_lib::config::Config;
+    /// use std::path::Path;
+    ///
+    /// // For a file located inside /home/user/aether_config.yaml we can construct
+    /// // a path
+    /// let path = Path::new("/home/user/aether_config.yaml");
+    ///
+    /// let config = Config::from_file(&path);
+    /// ```
+    pub fn from_file(file_path: &Path) -> Result<Config, AetherError> {
+        match fs::read_to_string(file_path) {
+            Ok(data) => match Config::try_from(data) {
+                Ok(config) => Ok(config),
+                Err(_) => Err(AetherError {
+                    code: 1007,
+                    description: String::from("Unable to parse config file"),
+                    cause: None,
+                }),
+            },
+            Err(err) => Err(AetherError {
+                code: 1008,
+                description: format!("Unable to read config file: {}", err),
+                cause: None,
+            }),
+        }
+    }
+
+    /// Returns configuration read from the default configuration file
+    /// If default configuration file is not found, the default internal configuration
+    /// is returned
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use aether_lib::config::Config;
+    /// let config = Config::get_config();
+    /// ```
+    pub fn get_config() -> Result<Config, AetherError> {
+        match home::home_dir() {
+            Some(mut path_buf) => {
+                path_buf.push(".config");
+                path_buf.push("aether");
+                path_buf.push("config.yaml");
+
+                let path = path_buf.as_path();
+
+                println!(
+                    "Reading configuration from {}",
+                    path.to_str().unwrap_or("Cannot parse path")
+                );
+
+                match Config::from_file(path) {
+                    Ok(config) => Ok(config),
+                    Err(err) => match err.code {
+                        1008 => {
+                            println!("{:?}", err);
+                            Ok(Config::default())
+                        }
+                        _ => Err(AetherError {
+                            code: 1009,
+                            description: String::from("Unable to read default config file"),
+                            cause: Some(Box::new(err)),
+                        }),
+                    },
+                }
+            }
+            None => Ok(Config::default()),
+        }
+    }
+}
+
+impl TryFrom<String> for Config {
+    type Error = serde_yaml::Error;
+    fn try_from(string: String) -> Result<Self, Self::Error> {
+        serde_yaml::from_str(&string)
+    }
+}
+
+impl TryFrom<Config> for String {
+    type Error = serde_yaml::Error;
+    fn try_from(value: Config) -> Result<Self, Self::Error> {
+        serde_yaml::to_string(&value)
+    }
 }
 
 impl Default for Config {
@@ -45,5 +141,26 @@ impl Default for AetherConfig {
             delta_time: 100,
             poll_time_us: 100,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::Config;
+    use std::{convert::TryFrom, fs, path::Path};
+
+    #[test]
+    fn read_test() {
+        let default = Config::default();
+
+        let path = "./tmp/config.yaml";
+
+        fs::create_dir_all("./tmp").unwrap();
+
+        fs::write(path, String::try_from(default).unwrap()).unwrap();
+
+        let config = Config::from_file(Path::new(path)).unwrap();
+
+        assert_eq!(config, default);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+//! Structures to represent errors in `aether_lib`
 use std::fmt::{Debug, Display, Formatter, Result};
 
 pub struct AetherError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! A library that provides P2P communication for Prototype Aether.
 
 pub mod acknowledgement;
+pub mod config;
 pub mod error;
 pub mod link;
 pub mod packet;

--- a/src/peer/handshake.rs
+++ b/src/peer/handshake.rs
@@ -3,19 +3,17 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use crate::{acknowledgement::Acknowledgement, packet::Packet};
+use crate::{acknowledgement::Acknowledgement, config::Config, packet::Packet};
 use crate::{link::Link, packet::PType};
 
 use rand::{thread_rng, Rng};
-
-const INITIATE_DELAY: u64 = 500;
-const HANDSHAKE_TIMEOUT: u64 = 5_000;
 
 pub fn handshake(
     socket: UdpSocket,
     address: SocketAddr,
     my_username: String,
     peer_username: String,
+    config: Config,
 ) -> Result<Link, u8> {
     let seq = thread_rng().gen_range(0..(1 << 16 as u32)) as u32;
     let recv_seq: u32;
@@ -23,7 +21,7 @@ pub fn handshake(
     let ack: bool;
 
     socket
-        .set_read_timeout(Some(Duration::from_millis(INITIATE_DELAY)))
+        .set_read_timeout(Some(Duration::from_millis(config.handshake.peer_poll_time)))
         .expect("Unable to set read timeout");
 
     let mut packet = Packet::new(PType::Initiation, seq);
@@ -36,7 +34,7 @@ pub fn handshake(
     loop {
         let elapsed = now.elapsed().expect("Unable to get system time");
 
-        if elapsed.as_millis() > HANDSHAKE_TIMEOUT.into() {
+        if elapsed.as_millis() > config.handshake.handshake_timeout.into() {
             return Err(255);
         }
 
@@ -82,7 +80,7 @@ pub fn handshake(
         loop {
             let elapsed = now.elapsed().expect("Unable to get system time");
 
-            if elapsed.as_millis() > HANDSHAKE_TIMEOUT.into() {
+            if elapsed.as_millis() > config.handshake.handshake_timeout.into() {
                 return Err(254);
             }
 

--- a/src/peer/handshake.rs
+++ b/src/peer/handshake.rs
@@ -111,7 +111,7 @@ pub fn handshake(
     }
 
     // Start the link
-    let mut link = Link::new(socket, address.clone(), seq, recv_seq);
+    let mut link = Link::new(socket, address.clone(), seq, recv_seq, config);
 
     link.start();
 

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -12,22 +12,30 @@ use std::net::{IpAddr, Ipv4Addr, UdpSocket};
 
 use rand::{thread_rng, Rng};
 
+use crate::config::Config;
 use crate::tracker::TrackerPacket;
 use crate::{link::Link, tracker::ConnectionRequest};
 
 use self::handshake::handshake;
 
+/*
 pub const SERVER_RETRY_DELAY: u64 = 1000;
 pub const SERVER_POLL_TIME: u64 = 1000;
 pub const HANDSHAKE_RETRY_DELAY: u64 = 5000;
 pub const CONNECTION_CHECK_DELAY: u64 = 1000;
 pub const DELTA_TIME: u64 = 100;
 pub const POLL_TIME_US: u64 = 100;
-
+*/
+/// Enumeration representing different states of a connection
 pub enum Connection {
+    /// Initialized state - connection has been initialized and is waiting to receive
+    /// other peer's public identity
     Init(Initialized),
+    /// Handshake state - handshake with the other peer is in progress
     Handshake,
+    /// Connected state - a connection to the other peer has been established
     Connected(Peer),
+    /// Failed state - a connection to the other peer had failed and would be retried
     Failed(Failure),
 }
 
@@ -74,14 +82,20 @@ pub struct Aether {
     requests: Arc<Mutex<VecDeque<ConnectionRequest>>>,
     /// Address of the tracker server
     tracker_addr: SocketAddr,
+    /// List of peers related to this peer
     connections: Arc<Mutex<HashMap<String, Connection>>>,
+    /// Configuration
+    config: Config,
 }
 
 impl Aether {
     pub fn new(username: String, tracker_addr: SocketAddr) -> Aether {
+        let config: Config = Default::default();
         let socket = Arc::new(UdpSocket::bind(("0.0.0.0", 0)).unwrap());
         socket
-            .set_read_timeout(Some(Duration::from_millis(SERVER_RETRY_DELAY)))
+            .set_read_timeout(Some(Duration::from_millis(
+                config.aether.server_retry_delay,
+            )))
             .expect("Unable to set read timeout");
         Aether {
             username,
@@ -89,6 +103,7 @@ impl Aether {
             tracker_addr,
             socket,
             connections: Arc::new(Mutex::new(HashMap::new())),
+            config,
         }
     }
 
@@ -146,7 +161,9 @@ impl Aether {
         if !self.is_initialized(username) {
             if self.is_connecting(username) {
                 while self.is_connecting(username) {
-                    thread::sleep(Duration::from_millis(CONNECTION_CHECK_DELAY));
+                    thread::sleep(Duration::from_millis(
+                        self.config.aether.connection_check_delay,
+                    ));
                 }
                 Ok(0)
             } else {
@@ -158,7 +175,9 @@ impl Aether {
             }
         } else {
             while !self.is_connected(username) {
-                thread::sleep(Duration::from_millis(CONNECTION_CHECK_DELAY));
+                thread::sleep(Duration::from_millis(
+                    self.config.aether.connection_check_delay,
+                ));
             }
             Ok(0)
         }
@@ -209,6 +228,7 @@ impl Aether {
         let my_username = self.username.clone();
         let connections = self.connections.clone();
         let tracker_addr = self.tracker_addr.clone();
+        let config = self.config;
         thread::spawn(move || {
             loop {
                 // Lock connections list
@@ -239,7 +259,7 @@ impl Aether {
 
                 // Unlock initailized list
                 drop(connections_lock);
-                thread::sleep(Duration::from_millis(SERVER_POLL_TIME));
+                thread::sleep(Duration::from_millis(config.aether.server_poll_time));
             }
         });
     }
@@ -282,6 +302,8 @@ impl Aether {
 
         let requests = self.requests.clone();
 
+        let config = self.config;
+
         thread::spawn(move || loop {
             socket
                 .send_to(&data_bytes, tracker_addr)
@@ -301,7 +323,7 @@ impl Aether {
                     (*req_lock).push_back(v);
                 }
 
-                thread::sleep(Duration::from_millis(SERVER_POLL_TIME));
+                thread::sleep(Duration::from_millis(config.aether.server_poll_time));
             }
         });
     }
@@ -311,6 +333,7 @@ impl Aether {
         let connections = self.connections.clone();
         let my_username = self.username.clone();
         let tracker_addr = self.tracker_addr.clone();
+        let config = self.config;
 
         thread::spawn(move || loop {
             let mut req_lock = requests.lock().expect("Unable to lock requests queue");
@@ -323,12 +346,13 @@ impl Aether {
                     &mut connections.clone(),
                     tracker_addr,
                     &mut req_lock,
+                    config,
                 ),
                 None => (),
             }
 
             drop(req_lock);
-            thread::sleep(Duration::from_micros(POLL_TIME_US));
+            thread::sleep(Duration::from_micros(config.aether.poll_time_us));
         });
     }
 }
@@ -339,6 +363,7 @@ fn handle_request(
     connections: &mut Arc<Mutex<HashMap<String, Connection>>>,
     tracker_addr: SocketAddr,
     req_lock: &mut MutexGuard<VecDeque<ConnectionRequest>>,
+    config: Config,
 ) {
     let mut connections_lock = connections.lock().expect("unable to lock failed list");
 
@@ -353,6 +378,8 @@ fn handle_request(
                     // Clone important data to pass to handshake thread
                     let connections_clone = connections.clone();
                     let my_username_clone = my_username.clone();
+
+                    let config_clone = config;
 
                     // Put current user in handshake state
                     (*connections_lock).insert(init.username.clone(), Connection::Handshake);
@@ -379,17 +406,18 @@ fn handle_request(
                         );
 
                         match link_result {
-                            Ok(mut link) => {
+                            Ok(link) => {
                                 println!("Handshake success");
 
                                 // Authentication
                                 // Send own username
                                 link.send(my_username_clone.clone().into_bytes());
-                                let delay = thread_rng().gen_range(0..DELTA_TIME);
+                                let delay =
+                                    thread_rng().gen_range(0..config_clone.aether.delta_time);
 
                                 // Receive other peer's username
                                 match link.recv_timeout(Duration::from_millis(
-                                    HANDSHAKE_RETRY_DELAY / 2 + delay,
+                                    config_clone.aether.handshake_retry_delay / 2 + delay,
                                 )) {
                                     Ok(recved) => {
                                         println!("Received nonce");
@@ -456,7 +484,7 @@ fn handle_request(
                     });
                 }
                 Connection::Failed(failed) => {
-                    let delta = thread_rng().gen_range(0..DELTA_TIME);
+                    let delta = thread_rng().gen_range(0..config.aether.delta_time);
                     let elapsed = failed
                         .time
                         .elapsed()
@@ -465,7 +493,7 @@ fn handle_request(
 
                     // if elapsed time since the fail is greater than threshold
                     // then put back in initialized state
-                    if elapsed > (HANDSHAKE_RETRY_DELAY + delta).into() {
+                    if elapsed > (config.aether.handshake_retry_delay + delta).into() {
                         (*connections_lock).insert(
                             failed.username.clone(),
                             Connection::Init(Initialized {

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -90,7 +90,7 @@ pub struct Aether {
 
 impl Aether {
     pub fn new(username: String, tracker_addr: SocketAddr) -> Aether {
-        let config: Config = Default::default();
+        let config = Config::get_config().expect("Error getting config");
         let socket = Arc::new(UdpSocket::bind(("0.0.0.0", 0)).unwrap());
         socket
             .set_read_timeout(Some(Duration::from_millis(
@@ -109,7 +109,6 @@ impl Aether {
 
     pub fn start(&self) {
         println!("Starting aether service...");
-        println!("Failure fix");
         self.connection_poll();
         self.handle_sockets();
         self.handle_requests();

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -18,14 +18,6 @@ use crate::{link::Link, tracker::ConnectionRequest};
 
 use self::handshake::handshake;
 
-/*
-pub const SERVER_RETRY_DELAY: u64 = 1000;
-pub const SERVER_POLL_TIME: u64 = 1000;
-pub const HANDSHAKE_RETRY_DELAY: u64 = 5000;
-pub const CONNECTION_CHECK_DELAY: u64 = 1000;
-pub const DELTA_TIME: u64 = 100;
-pub const POLL_TIME_US: u64 = 100;
-*/
 /// Enumeration representing different states of a connection
 pub enum Connection {
     /// Initialized state - connection has been initialized and is waiting to receive

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -394,6 +394,7 @@ fn handle_request(
                             peer_addr,
                             my_username_clone.clone(),
                             peer_username.clone(),
+                            config_clone,
                         );
 
                         match link_result {

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -3,6 +3,7 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
     use std::thread;
 
+    use aether_lib::config::Config;
     use aether_lib::link::Link;
     use aether_lib::peer::handshake::handshake;
     #[test]
@@ -82,6 +83,7 @@ mod tests {
                 peer_addr2,
                 String::from("peer1"),
                 String::from("peer2"),
+                Config::default(),
             )
             .expect("Handshake failed");
 
@@ -107,6 +109,7 @@ mod tests {
                 peer_addr1,
                 String::from("peer2"),
                 String::from("peer1"),
+                Config::default(),
             )
             .expect("Handshake failed");
 

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -18,8 +18,8 @@ mod tests {
         peer_addr1.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
         peer_addr2.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
 
-        let mut link1 = Link::new(socket1, peer_addr2, 0, 1000);
-        let mut link2 = Link::new(socket2, peer_addr1, 1000, 0);
+        let mut link1 = Link::new(socket1, peer_addr2, 0, 1000, Config::default());
+        let mut link2 = Link::new(socket2, peer_addr1, 1000, 0, Config::default());
 
         println!("{:?} {:?}", peer_addr1, peer_addr2);
 


### PR DESCRIPTION
Up until now, we were using constants to represent certain parameters such as polling time, window size etc. To make these parameters much more configurable as well as be able to optimize by tweaking these parameters, we decided to have a configuration file to store all these constants that is read during runtime.

So, implemented a `Config` structure to represent this configuration. This structure can then be serialized and de-serialized by [`serde`](https://crates.io/crates/serde). The configuration file is stored in [YAML](https://yaml.org/) format using [`serde_yaml`](https://crates.io/crates/serde_yaml).

The `Default` trait is implemented for `Config` with constant values that we were using till now. When missing values are detected in the configuration file, the values are replaced with default. But it might give unexpected issues like if a configuration file sets timeout values but not poll time values, and the timeout is less than some of the polling time default values, then the timeout would be triggered before normal operations are complete.

This is what the configuration file looks like (default values used)
```yaml
---
aether:
  server_retry_delay: 1000
  server_poll_time: 1000
  handshake_retry_delay: 5000
  connection_check_delay: 1000
  delta_time: 100
  poll_time_us: 100
handshake:
  peer_poll_time: 500
  handshake_timeout: 5000
link:
  window_size: 20
  ack_wait_time: 1000
  poll_time_us: 100
  timeout: 10000
  retry_delay: 100
  max_retries: 10
```