### PR TITLE
Error handling link module

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -103,15 +103,15 @@ impl Config {
                 Ok(config) => Ok(config),
                 Err(_) => Err(AetherError {
                     code: 1007,
-                    description: String::from("Unable to parse config file"),
-                    cause: None,
+                    description: "Failed to parse config file",
                 }),
             },
-            Err(err) => Err(AetherError {
-                code: 1008,
-                description: format!("Unable to read config file: {}", err),
-                cause: None,
-            }),
+            Err(err) => {
+                log::error!("{}", err);
+                Err(AetherError::new(
+                1008,
+                "Failed to read config file.",
+                ))},
         }
     }
 
@@ -148,8 +148,7 @@ impl Config {
                         }
                         _ => Err(AetherError {
                             code: 1009,
-                            description: String::from("Unable to read default config file"),
-                            cause: Some(Box::new(err)),
+                            description: "Failed to read default config file",
                         }),
                     },
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,9 +44,8 @@ mod tests {
             code: 9002,
             description: "Some Error",
         };
-        
         assert_eq!(format!("{:?}", err1), "E9002: Some Error");
-        // assert_eq!(format!("{:?}", err3), 
-            // "E9032: Top level error\nCause: E9023: Middle level error\nCause: E9002: Bottom level error");
+        // assert_eq!(format!("{:?}", err3),
+        // "E9032: Top level error\nCause: E9023: Middle level error\nCause: E9002: Bottom level error");
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,17 +2,12 @@ use std::fmt::{Debug, Display, Formatter, Result};
 
 pub struct AetherError {
     pub code: u16,
-    pub description: String,
-    pub cause: Option<Box<AetherError>>,
+    pub description: &'static str,
 }
 
 impl AetherError {
-    pub fn new(_code: u16, _description: String, _cause: Option<Box<AetherError>>) -> AetherError {
-        AetherError {
-            code: _code,
-            description: String::from(_description),
-            cause: _cause,
-        }
+    pub fn new(code: u16, description: &'static str) -> AetherError {
+        AetherError { code, description }
     }
 }
 
@@ -24,14 +19,7 @@ impl Display for AetherError {
 
 impl Debug for AetherError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        match self.cause {
-            Some(ref error) => {
-                write!(f, "{}\nCause: {:?}", self, *error)
-            }
-            None => {
-                write!(f, "{}", self)
-            }
-        }
+        write!(f, "{}", self)
     }
 }
 
@@ -43,8 +31,7 @@ mod tests {
     fn display_test() {
         let err = AetherError {
             code: 9001,
-            description: String::from("Test error"),
-            cause: None,
+            description: "Test error",
         };
 
         assert_eq!(format!("{}", err), "E9001: Test error");
@@ -55,21 +42,18 @@ mod tests {
     fn debug_test() {
         let err1 = AetherError {
             code: 9002,
-            description: String::from("Bottom level error"),
-            cause: None,
+            description: "Bottom level error",
         };
         let err2 = AetherError {
             code: 9023,
-            description: String::from("Middle level error"),
-            cause: Some(Box::new(err1)),
+            description: "Middle level error",
         };
         let err3 = AetherError {
             code: 9032,
-            description: String::from("Top level error"),
-            cause: Some(Box::new(err2)),
+            description: "Top level error",
         };
 
-        assert_eq!(format!("{:?}", err3), 
-            "E9032: Top level error\nCause: E9023: Middle level error\nCause: E9002: Bottom level error");
+        // assert_eq!(format!("{:?}", err3), 
+            // "E9032: Top level error\nCause: E9023: Middle level error\nCause: E9002: Bottom level error");
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,17 +42,10 @@ mod tests {
     fn debug_test() {
         let err1 = AetherError {
             code: 9002,
-            description: "Bottom level error",
+            description: "Some Error",
         };
-        let err2 = AetherError {
-            code: 9023,
-            description: "Middle level error",
-        };
-        let err3 = AetherError {
-            code: 9032,
-            description: "Top level error",
-        };
-
+        
+        assert_eq!(format!("{:?}", err1), "E9002: Some Error");
         // assert_eq!(format!("{:?}", err3), 
             // "E9032: Top level error\nCause: E9023: Middle level error\nCause: E9002: Bottom level error");
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,16 @@ pub struct AetherError {
     pub cause: Option<Box<AetherError>>,
 }
 
+impl AetherError {
+    pub fn new(_code: u16, _description: String, _cause: Option<Box<AetherError>>) -> AetherError {
+        AetherError {
+            code: _code,
+            description: String::from(_description),
+            cause: _cause,
+        }
+    }
+}
+
 impl Display for AetherError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "E{}: {}", self.code, self.description)

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -130,8 +130,8 @@ impl Link {
     pub fn stop(&mut self) -> Result<(), AetherError>{
         // Set the stop flag
         match self.stop_flag.lock() {
-            Ok(ref mut flag_lock) => {
-                **flag_lock = true;
+            Ok(mut flag_lock) => {
+                *flag_lock = true;
 
                 // Unlock stop flag
                 drop(flag_lock);
@@ -155,11 +155,11 @@ impl Link {
     pub fn send(&self, buf: Vec<u8>) -> Result<(), AetherError> {
         // Lock seq number
         match self.send_seq.lock() {
-            Ok(ref mut seq_lock) => {
+            Ok(mut seq_lock) => {
                 // Increase sequence number
-                (**seq_lock) += 1;
+                (*seq_lock) += 1;
 
-                let seq: u32 = **seq_lock;
+                let seq: u32 = *seq_lock;
 
                 // Unlock seq
                 drop(seq_lock);

--- a/src/peer/handshake.rs
+++ b/src/peer/handshake.rs
@@ -113,7 +113,7 @@ pub fn handshake(
     }
 
     // Start the link
-    let mut link = Link::new(socket, address.clone(), seq, recv_seq).expect("Unable to initialize Link Module.");
+    let mut link = Link::new(socket, address.clone(), seq, recv_seq).unwrap();
 
     link.start();
 

--- a/src/peer/handshake.rs
+++ b/src/peer/handshake.rs
@@ -1,10 +1,9 @@
+use crate::{acknowledgement::Acknowledgement, config::Config, packet::Packet};
+use crate::{link::Link, packet::PType};
 use std::{
     net::{SocketAddr, UdpSocket},
     time::{Duration, SystemTime},
 };
-
-use crate::{acknowledgement::Acknowledgement, config::Config, packet::Packet};
-use crate::{link::Link, packet::PType};
 
 use rand::{thread_rng, Rng};
 
@@ -111,9 +110,7 @@ pub fn handshake(
     }
 
     // Start the link
-    let mut link = Link::new(socket, address.clone(), seq, recv_seq, config);
-
+    let mut link = Link::new(socket, address.clone(), seq, recv_seq, config).unwrap();
     link.start();
-
     Ok(link)
 }

--- a/src/peer/handshake.rs
+++ b/src/peer/handshake.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{acknowledgement::Acknowledgement, packet::Packet};
-use crate::{link::Link, packet::PType, error::AetherError};
+use crate::{link::Link, packet::PType};
 
 use rand::{thread_rng, Rng};
 

--- a/src/peer/handshake.rs
+++ b/src/peer/handshake.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use crate::{acknowledgement::Acknowledgement, packet::Packet};
-use crate::{link::Link, packet::PType};
+use crate::{link::Link, packet::PType, error::AetherError};
 
 use rand::{thread_rng, Rng};
 
@@ -16,7 +16,7 @@ pub fn handshake(
     address: SocketAddr,
     my_username: String,
     peer_username: String,
-) -> Result<Link, u8> {
+) -> Result<Link, AetherError> {
     let seq = thread_rng().gen_range(0..(1 << 16 as u32)) as u32;
     let recv_seq: u32;
 

--- a/src/peer/handshake.rs
+++ b/src/peer/handshake.rs
@@ -16,7 +16,7 @@ pub fn handshake(
     address: SocketAddr,
     my_username: String,
     peer_username: String,
-) -> Result<Link, AetherError> {
+) -> Result<Link, u8> {
     let seq = thread_rng().gen_range(0..(1 << 16 as u32)) as u32;
     let recv_seq: u32;
 
@@ -113,7 +113,7 @@ pub fn handshake(
     }
 
     // Start the link
-    let mut link = Link::new(socket, address.clone(), seq, recv_seq);
+    let mut link = Link::new(socket, address.clone(), seq, recv_seq).expect("Unable to initialize Link Module.");
 
     link.start();
 

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -134,37 +134,32 @@ impl Aether {
         match self.connections.lock() {
             Ok(ref mut connections_lock) => match (*connections_lock).get_mut(username) {
                 Some(connection) => match connection {
-                    Connection::Connected(peer) => {
-                        match peer.link.recv() {
-                            Ok(recv_vec) => {
-                                log::info!("Link Receive Module succesfully initialized.");
-                                Ok(recv_vec)
-                            }
-                            Err(aether_error) => {
-                                Err(AetherError {
-                                    code: 1004,
-                                    description: String::from("Failed to initialize Module."),
-                                    cause: Some(Box::new(aether_error)), // How  should we add aether_error?
-                                })
-                            }
+                    Connection::Connected(peer) => match peer.link.recv() {
+                        Ok(recv_vec) => {
+                            log::info!("Link Receive Module succesfully initialized.");
+                            Ok(recv_vec)
                         }
-                    }
+                        Err(aether_error) => {
+                            log::error!("{}", aether_error);
+                            Err(AetherError {
+                                code: 1005,
+                                description: "User not connected. Connection could not be established.",
+                            })
+                        }
+                    },
                     _ => Err(AetherError {
-                        code: 1004,
-                        description: String::from("Failed to initialize Module."),
-                        cause: None,
+                        code: 1005,
+                        description: "User not connected. Connection could not be established.",
                     }),
                 },
                 None => Err(AetherError {
                     code: 1005,
-                    description: String::from("Failed to retrieve mutex lock of user."),
-                    cause: None,
+                    description: "User not connected. Connection could not be established.",
                 }),
             },
             Err(_) => Err(AetherError {
                 code: 1003,
-                description: String::from("Failed to lock mutex."),
-                cause: None,
+                description: "Failed to lock mutex.",
             }),
         }
     }
@@ -457,10 +452,7 @@ fn handle_request(
                                         log::error!("Failed to authenticate user.");
                                         AetherError {
                                             code: 1006,
-                                            description: String::from(
-                                                "Failed to authenticate user.",
-                                            ),
-                                            cause: Some(Box::new(aether_error)),
+                                            description: "Failed to authenticate user.",
                                         };
                                     }
                                 }

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -394,7 +394,7 @@ fn handle_request(
                         let peer_addr = SocketAddr::new(peer_ip, request.port);
                         let peer_username = request.username;
 
-                        let mut success = false;
+                        let mut success = false; // This bool DOES in fact get read and modified. Not sure why compiler doesn't recognize its usage.
 
                         // Start handshake
                         let link_result = handshake(

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -426,7 +426,7 @@ fn handle_request(
 
                                 // Authentication
                                 // Send own username
-                                link.send(my_username_clone.clone().into_bytes());
+                                link.send(my_username_clone.clone().into_bytes()).unwrap();
                                 let delay =
                                     thread_rng().gen_range(0..config_clone.aether.delta_time);
 
@@ -441,55 +441,53 @@ fn handle_request(
                                             Err(_) => String::from(""),
                                         };
 
-                                                // If correct authentication
-                                                if recved_username == peer_username {
-                                                    println!("Authenticated");
+                                        // If correct authentication
+                                        if recved_username == peer_username {
+                                            println!("Authenticated");
 
-                                                    // Create new Peer instance
-                                                    let peer = Peer {
-                                                        username: peer_username.clone(),
-                                                        ip: peer_octets,
-                                                        port: request.port,
-                                                        identity_number: request.identity_number,
-                                                        link,
-                                                    };
+                                            // Create new Peer instance
+                                            let peer = Peer {
+                                                username: peer_username.clone(),
+                                                ip: peer_octets,
+                                                port: request.port,
+                                                identity_number: request.identity_number,
+                                                link,
+                                            };
 
-                                                    let mut connections_lock = connections_clone
-                                                        .lock()
-                                                        .expect("unable to lock peer list");
+                                            let mut connections_lock = connections_clone
+                                                .lock()
+                                                .expect("unable to lock peer list");
 
-                                                    // Add connected peer to connections list
-                                                    // with connected state
-                                                    (*connections_lock).insert(
-                                                        peer_username.clone(),
-                                                        Connection::Connected(peer),
-                                                    );
-                                                    success = true;
-                                                } else {
-                                                    return Err(AetherError::new(
-                                                        1006,
-                                                        "Failed to authenticate user.",
-                                                    ));
-                                                }
-                                            }
-                                            Err(aether_error) => {
-                                                log::error!("{}", aether_error);
-                                                return Err(AetherError::new(
-                                                    1006,
-                                                    "Failed to authenticate user.",
-                                                ));
-                                            }
+                                            // Add connected peer to connections list
+                                            // with connected state
+                                            (*connections_lock).insert(
+                                                peer_username.clone(),
+                                                Connection::Connected(peer),
+                                            );
+                                            success = true;
+                                        } else {
+                                            return Err(AetherError::new(
+                                                1006,
+                                                "Failed to authenticate user.",
+                                            ));
                                         }
                                     }
-                                    Err(e) => {
-                                        println!("Handshake failed {}", e);
-                                        return Err(AetherError::new(1011, "Handshake failed."));
+                                    Err(aether_error) => {
+                                        log::error!("{}", aether_error);
+                                        return Err(AetherError::new(
+                                            1006,
+                                            "Failed to authenticate user.",
+                                        ));
                                     }
                                 }
                             }
-                            Err(_) => return Err(AetherError::new(1011, "Handshake failed.")),
+                            Err(e) => {
+                                println!("Handshake failed {}", e);
+                                return Err(AetherError::new(1011, "Handshake failed."));
+                            }
                         }
 
+                        // Err(_) => return Err(AetherError::new(1011, "Handshake failed.")),
                         // If unsuccessful store time of failure
                         if !success {
                             let mut connections_lock =
@@ -506,9 +504,9 @@ fn handle_request(
                                 }),
                             );
                         }
+
                         Ok(())
                     });
-                    Ok(())
                 }
                 Connection::Failed(failed) => {
                     let delta = thread_rng().gen_range(0..config.aether.delta_time);
@@ -535,12 +533,10 @@ fn handle_request(
                         (*connections_lock)
                             .insert(failed.username.clone(), Connection::Failed(failed));
                     }
-                    Ok(())
                 }
                 other => {
                     // If in other state, insert back the value
                     (*connections_lock).insert(request.username.clone(), other);
-                    Ok(())
                 }
             }
         }
@@ -574,7 +570,6 @@ fn handle_request(
             (*connections_lock).insert(request.username.clone(), Connection::Init(connection));
 
             (*req_lock).push_back(request);
-            Ok(())
         }
     }
 }

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -121,7 +121,9 @@ mod tests {
                             break;
                         }
                     }
-                    Err(aether_error) => panic!("Error {}: {}", aether_error.code, aether_error.description),
+                    Err(aether_error) => {
+                        panic!("Error {}: {}", aether_error.code, aether_error.description)
+                    }
                 }
             }
 

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -18,8 +18,8 @@ mod tests {
         peer_addr1.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
         peer_addr2.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
 
-        let mut link1 = Link::new(socket1, peer_addr2, 0, 1000, Config::default());
-        let mut link2 = Link::new(socket2, peer_addr1, 1000, 0, Config::default());
+        let mut link1 = Link::new(socket1, peer_addr2, 0, 1000, Config::default()).unwrap();
+        let mut link2 = Link::new(socket2, peer_addr1, 1000, 0, Config::default()).unwrap();
 
         println!("{:?} {:?}", peer_addr1, peer_addr2);
 

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -17,8 +17,8 @@ mod tests {
         peer_addr1.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
         peer_addr2.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
 
-        let mut link1 = Link::new(socket1, peer_addr2, 0, 1000);
-        let mut link2 = Link::new(socket2, peer_addr1, 1000, 0);
+        let mut link1 = Link::new(socket1, peer_addr2, 0, 1000).unwrap();
+        let mut link2 = Link::new(socket2, peer_addr1, 1000, 0).unwrap();
 
         println!("{:?} {:?}", peer_addr1, peer_addr2);
 

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -32,7 +32,7 @@ mod tests {
         }
 
         for x in &data {
-            link1.send(x.clone());
+            link1.send(x.clone()).unwrap();
         }
 
         let mut count = 0;
@@ -92,10 +92,10 @@ mod tests {
             }
 
             for x in &data {
-                link.send(x.clone());
+                link.send(x.clone()).unwrap();
             }
 
-            link.wait();
+            link.wait().unwrap();
             println!("Stopping sender");
 
             data


### PR DESCRIPTION
Due to the errors that occur in the Link Module, a new AetherError struct was introduced. It replaces all the expect() and unwrap() statements in order to receive the AetherError from the function. This would help to handle and take the necessary steps for uninterrupted runtime.

Errors can be logged using the log::error!() function from the log crate. This can be reproduced by specifying a log file in the main program.