### PR TITLE
Changed to an enumeration based implementation for AetherError

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,4 +16,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run tests
-      run: cargo test -- --nocapture
+      run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "thiserror",
 ]
 
 [[package]]
@@ -340,6 +341,26 @@ dependencies = [
  "byteorder",
  "dirs",
  "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0"
 serde_yaml = "0.8"
 home = "0.5"
 log = "0.4"
+thiserror = "1.0"
 
 [dev-dependencies]
 clippy = "*"

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,17 +101,9 @@ impl Config {
         match fs::read_to_string(file_path) {
             Ok(data) => match Config::try_from(data) {
                 Ok(config) => Ok(config),
-                Err(_) => Err(AetherError {
-                    code: 1007,
-                    description: "Failed to parse config file",
-                }),
+                Err(err) => Err(AetherError::YamlParse(err)),
             },
-            Err(err) => {
-                log::error!("{}", err);
-                Err(AetherError::new(
-                1008,
-                "Failed to read config file.",
-                ))},
+            Err(err) => Err(AetherError::FileRead(err)),
         }
     }
 
@@ -141,15 +133,12 @@ impl Config {
 
                 match Config::from_file(path) {
                     Ok(config) => Ok(config),
-                    Err(err) => match err.code {
-                        1008 => {
-                            println!("{:?}", err);
+                    Err(err) => match err {
+                        AetherError::FileRead(file_err) => {
+                            println!("{:?}", file_err);
                             Ok(Config::default())
                         }
-                        _ => Err(AetherError {
-                            code: 1009,
-                            description: "Failed to read default config file",
-                        }),
+                        _ => Err(err),
                     },
                 }
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,52 +1,26 @@
 //! Structures to represent errors in `aether_lib`
-use std::fmt::{Debug, Display, Formatter, Result};
+use std::fmt::Debug;
+use std::time::SystemTimeError;
+use thiserror::Error;
 
-pub struct AetherError {
-    pub code: u16,
-    pub description: &'static str,
-}
-
-impl AetherError {
-    pub fn new(code: u16, description: &'static str) -> AetherError {
-        AetherError { code, description }
-    }
-}
-
-impl Display for AetherError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "E{}: {}", self.code, self.description)
-    }
-}
-
-impl Debug for AetherError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{}", self)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::error::AetherError;
-
-    #[test]
-    fn display_test() {
-        let err = AetherError {
-            code: 9001,
-            description: "Test error",
-        };
-
-        assert_eq!(format!("{}", err), "E9001: Test error");
-    }
-
-    #[test]
-
-    fn debug_test() {
-        let err1 = AetherError {
-            code: 9002,
-            description: "Some Error",
-        };
-        assert_eq!(format!("{:?}", err1), "E9002: Some Error");
-        // assert_eq!(format!("{:?}", err3),
-        // "E9032: Top level error\nCause: E9023: Middle level error\nCause: E9002: Bottom level error");
-    }
+#[derive(Error, Debug)]
+pub enum AetherError {
+    #[error("Current time is from future so cannot calculate elapsed time")]
+    ElapsedTime(#[from] SystemTimeError),
+    #[error("Failed to lock a mutex")]
+    MutexLock(&'static str),
+    #[error("Link module stopped")]
+    LinkStopped(&'static str),
+    #[error("Receive timed out")]
+    RecvTimeout,
+    #[error("Link timed out")]
+    LinkTimeout,
+    #[error("Failed to set read timeout on socket")]
+    SetReadTimeout,
+    #[error("User not connected")]
+    NotConnected(String),
+    #[error("Error parsing yaml string")]
+    YamlParse(#[from] serde_yaml::Error),
+    #[error("Error reading file")]
+    FileRead(#[from] std::io::Error),
 }

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -143,7 +143,7 @@ impl Aether {
                     }
                     Err(aether_error) => Err(aether_error),
                 },
-                _ => Err(AetherError::NotConnected(username.clone())),
+                _ => Err(AetherError::NotConnected(username.to_string())),
             },
             Err(_) => Err(AetherError::MutexLock("connections")),
         }
@@ -175,7 +175,10 @@ impl Aether {
 
     pub fn is_connected(&self, username: &str) -> bool {
         let connections_lock = self.connections.lock().expect("unable to lock peers list");
-        matches!((*connections_lock).get(username), Some(Connection::Connected(_)))
+        matches!(
+            (*connections_lock).get(username),
+            Some(Connection::Connected(_))
+        )
     }
 
     pub fn is_connecting(&self, username: &str) -> bool {

--- a/tests/aether_test.rs
+++ b/tests/aether_test.rs
@@ -3,7 +3,7 @@ mod tests {
 
     use std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
-        process::{Command, Stdio},
+        process::Command,
         thread,
     };
 

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -120,8 +120,8 @@ mod tests {
                             break;
                         }
                     }
-                    Err(aether_error) => {
-                        panic!("Error {}: {}", aether_error.code, aether_error.description)
+                    Err(err) => {
+                        panic!("Error {}", err);
                     }
                 }
             }


### PR DESCRIPTION
Changed `struct AetherError` to `enum AetherError` with various errors as its members. Using [`thiserror`](https://crates.io/crates/thiserror) crate to help with the implementation.

This should improve performance as well as help the compiler optimize more easily. This will also make it easy to keep track of all the different errors. Since most of the errors are for internal use, error codes aren't essential. If there needs to be an error code system to be implemented in the future then we can simply map some of the errors to error codes.