### PR TITLE
Proper logging and Fixed Data Race in `recv_from`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@
 //! leave any missing values in the configuration file as the values need to follow certain
 //! constaints. For example, `handshake_timeout` cannot be smaller than `peer_poll_time` because in
 //! such a case, the handshake would timeout before even a single poll is complete.
+use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, default::Default, fs, path::Path};
 
@@ -129,7 +130,7 @@ impl Config {
 
                 let path = path_buf.as_path();
 
-                println!(
+                info!(
                     "Reading configuration from {}",
                     path.to_str().unwrap_or("Cannot parse path")
                 );
@@ -138,7 +139,7 @@ impl Config {
                     Ok(config) => Ok(config),
                     Err(err) => match err {
                         AetherError::FileRead(file_err) => {
-                            println!("{:?}", file_err);
+                            warn!("{:?}", file_err);
                             Ok(Config::default())
                         }
                         _ => Err(err),

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,4 +37,6 @@ pub enum AetherError {
     FromUtf8Error(#[from] FromUtf8Error),
     #[error("Error decoding base64 string")]
     Base64DecodeError(#[from] base64::DecodeError),
+    #[error("Handshake couldn't complete")]
+    HandshakeError,
 }

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -46,6 +46,7 @@
 //! ```
 use std::{fs, path::PathBuf};
 
+use log::warn;
 use openssl::{
     pkey::{Private, Public},
     rsa::{Padding, Rsa},
@@ -147,7 +148,7 @@ impl Id {
         match Self::load() {
             Ok(id) => Ok(id),
             Err(AetherError::FileRead(err)) => {
-                println!("Error reading key: {}", err);
+                warn!("Unable to read key: {}", err);
                 let new_id = Self::new()?;
                 match new_id.save() {
                     Ok(()) => Ok(new_id),

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -82,11 +82,8 @@ impl Link {
         let socket = Arc::new(socket);
 
         // if - let for errors
-        match socket.set_read_timeout(Some(Duration::from_secs(1))) {
-            Ok(_) => {}
-            Err(_) => {
-                return Err(AetherError::SetReadTimeout);
-            }
+        if let Err(_) = socket.set_read_timeout(Some(Duration::from_secs(1))) {
+            return Err(AetherError::SetReadTimeout);
         }
 
         let primary_queue = Arc::new(Mutex::new(VecDeque::new()));

--- a/src/link/receivethread.rs
+++ b/src/link/receivethread.rs
@@ -119,7 +119,6 @@ impl ReceiveThread {
 
     pub fn start(&mut self) {
         let mut buf = [0; 512];
-        //println!("Starting receive thread...");
         let mut now = SystemTime::now();
         loop {
             // If stop flag is set stop the thread
@@ -158,7 +157,6 @@ impl ReceiveThread {
                 }
             }
         }
-        //println!("Stopping receive thread...");
     }
 
     fn check_ack(&self, packet: &Packet) -> bool {

--- a/src/peer/authentication.rs
+++ b/src/peer/authentication.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use crate::identity::PublicId;
 use crate::peer::Peer;
 use crate::{error::AetherError, util::gen_nonce};
+use log::info;
 use rand::{thread_rng, Rng};
 
 use crate::{config::Config, link::Link};
@@ -55,7 +56,7 @@ pub fn authenticate(
 
     // if nonce received is same as nonce sent, the other peer is authenticated
     if nonce == nonce_recv {
-        println!("Authenticated");
+        info!("Authenticated: {}", peer_uid);
 
         // Create new Peer instance
         let peer = Peer {

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -344,10 +344,8 @@ impl Aether {
         let private_id = self.private_id.clone();
 
         thread::spawn(move || loop {
-            trace!("getting lock");
             let mut req_lock = requests.lock().expect("Unable to lock requests queue");
 
-            trace!("checking requests");
             // For each request received
             if let Some(request) = (*req_lock).pop_front() {
                 trace!("some request");

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -180,8 +180,11 @@ impl Aether {
 
     pub fn wait_connection(&self, uid: &str) -> Result<u8, u8> {
         if !self.is_initialized(uid) {
+            trace!("init");
             if self.is_connecting(uid) {
+                trace!("connecting");
                 while self.is_connecting(uid) {
+                    trace!("waiting");
                     thread::sleep(Duration::from_millis(
                         self.config.aether.connection_check_delay,
                     ));
@@ -194,6 +197,7 @@ impl Aether {
             }
         } else {
             while !self.is_connected(uid) {
+                trace!("waiting");
                 thread::sleep(Duration::from_millis(
                     self.config.aether.connection_check_delay,
                 ));

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -347,6 +347,7 @@ impl Aether {
 
             // For each request received
             if let Some(request) = (*req_lock).pop_front() {
+                trace!("some request");
                 Self::handle_request(
                     private_id.clone(),
                     request,

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -309,6 +309,7 @@ impl Aether {
         let config = self.config;
 
         thread::spawn(move || loop {
+            trace!("polling tracker");
             socket
                 .send_to(&data_bytes, tracker_addr)
                 .expect("Unable to send to server");
@@ -319,6 +320,7 @@ impl Aether {
             };
 
             if !response_data.is_empty() {
+                trace!("Received request from server");
                 let response_packet =
                     TrackerPacket::try_from(response_data).expect("Unable to decode packet");
 

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -1,6 +1,8 @@
 pub mod authentication;
 pub mod handshake;
 
+use log::{error, trace};
+
 use std::collections::VecDeque;
 use std::convert::TryFrom;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -119,7 +121,7 @@ impl Aether {
     }
 
     pub fn start(&self) {
-        println!("Starting aether service...");
+        trace!("Starting aether service...");
         self.connection_poll();
         self.handle_sockets();
         self.handle_requests();
@@ -387,7 +389,7 @@ impl Aether {
 
             match link_result {
                 Ok(link) => {
-                    println!("Handshake success");
+                    trace!("Handshake success");
 
                     match authenticate(link, peer_uid.clone(), request.identity_number, config) {
                         Ok(peer) => {
@@ -401,10 +403,10 @@ impl Aether {
                             success = true;
                         }
                         Err(AetherError::AuthenticationFailed(_)) => {
-                            println!("Cannot reach");
+                            trace!("Cannot reach");
                         }
                         Err(AetherError::AuthenticationInvalid(_)) => {
-                            println!("Identity could not be authenticated")
+                            error!("Identity could not be authenticated")
                         }
                         Err(other) => {
                             panic!("Unexpected error {}", other);
@@ -412,7 +414,7 @@ impl Aether {
                     }
                 }
                 Err(e) => {
-                    println!("Handshake failed {}", e);
+                    trace!("Handshake failed {}", e);
                 }
             }
 

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -324,6 +324,8 @@ impl Aether {
                 let response_packet =
                     TrackerPacket::try_from(response_data).expect("Unable to decode packet");
 
+                trace!("decoded packet {:?}", response_packet);
+
                 for v in response_packet.connections {
                     trace!("{:?}", v);
                     let mut req_lock = requests.lock().expect("unable to lock request queue");

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -344,8 +344,10 @@ impl Aether {
         let private_id = self.private_id.clone();
 
         thread::spawn(move || loop {
+            trace!("getting lock");
             let mut req_lock = requests.lock().expect("Unable to lock requests queue");
 
+            trace!("checking requests");
             // For each request received
             if let Some(request) = (*req_lock).pop_front() {
                 trace!("some request");

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -325,8 +325,10 @@ impl Aether {
                     TrackerPacket::try_from(response_data).expect("Unable to decode packet");
 
                 for v in response_packet.connections {
+                    trace!("{:?}", v);
                     let mut req_lock = requests.lock().expect("unable to lock request queue");
                     (*req_lock).push_back(v);
+                    trace!("{:?}", *req_lock);
                 }
 
                 thread::sleep(Duration::from_millis(config.aether.server_poll_time));

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -180,11 +180,8 @@ impl Aether {
 
     pub fn wait_connection(&self, uid: &str) -> Result<u8, u8> {
         if !self.is_initialized(uid) {
-            trace!("init");
             if self.is_connecting(uid) {
-                trace!("connecting");
                 while self.is_connecting(uid) {
-                    trace!("waiting");
                     thread::sleep(Duration::from_millis(
                         self.config.aether.connection_check_delay,
                     ));
@@ -197,7 +194,6 @@ impl Aether {
             }
         } else {
             while !self.is_connected(uid) {
-                trace!("waiting");
                 thread::sleep(Duration::from_millis(
                     self.config.aether.connection_check_delay,
                 ));

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -370,6 +370,7 @@ impl Aether {
         req_lock: &mut MutexGuard<VecDeque<ConnectionRequest>>,
         config: Config,
     ) {
+        trace!("got request");
         let mut connections_lock = connections.lock().expect("unable to lock failed list");
         // Clone important data to pass to handshake thread
         let connections_clone = connections.clone();
@@ -385,6 +386,7 @@ impl Aether {
 
             let mut success = false; // This bool DOES in fact get read and modified. Not sure why compiler doesn't recognize its usage.
 
+            trace!("starting handshake");
             // Start handshake
             let link_result = handshake(
                 private_id,
@@ -455,6 +457,7 @@ impl Aether {
                 // Put current user in handshake state
                 (*connections_lock).insert(init.uid.clone(), Connection::Handshake);
 
+                trace!("Got initialized");
                 // Create a thread to start handshake and establish connection
                 thread::spawn(move || handshake_thread(init, request));
             }

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -401,13 +401,16 @@ impl Aether {
 
                     match authenticate(link, peer_uid.clone(), request.identity_number, config) {
                         Ok(peer) => {
+                            trace!("got peer");
                             let mut connections_lock =
                                 connections_clone.lock().expect("unable to lock peer list");
 
+                            trace!("got connections lock");
                             // Add connected peer to connections list
                             // with connected state
                             (*connections_lock)
                                 .insert(peer_uid.clone(), Connection::Connected(Box::new(peer)));
+                            trace!("inserted connected");
                             success = true;
                         }
                         Err(AetherError::AuthenticationFailed(_)) => {

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -335,6 +335,7 @@ impl Aether {
     }
 
     fn handle_requests(&self) {
+        trace!("Handle thread...");
         let requests = self.requests.clone();
         let connections = self.connections.clone();
         let my_uid = self.uid.clone();


### PR DESCRIPTION
Replaced `println` with functions from the `log` crate for a more proper logging.

There was a logical bug in the `recv_from` function where it would lock the `connections` list and that would prevent `send_to` from being able to send anything. Changed `recv_from` to a poll `recv_timeout` instead which solves the issue. However this is not optimal and hopefully using `mpsc` or `crossbeam` should give a better solution.