### PR TITLE
Changed primary and output queue to use crossbeam unbounded channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "clippy",
+ "crossbeam",
  "home",
  "log",
  "openssl",
@@ -91,6 +92,65 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "crossbeam"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -206,6 +266,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -345,6 +414,12 @@ name = "ryu"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ log = "0.4"
 thiserror = "1.0"
 openssl = "0.10"
 base64 = "0.13"
+crossbeam = "0.8"
 
 [dev-dependencies]
 clippy = "*"

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,10 @@ use std::string::FromUtf8Error;
 use std::time::SystemTimeError;
 use thiserror::Error;
 
+use crossbeam::channel::SendError;
+
+use crate::packet::Packet;
+
 #[derive(Error, Debug)]
 pub enum AetherError {
     #[error("Current time is from future so cannot calculate elapsed time")]
@@ -39,4 +43,6 @@ pub enum AetherError {
     Base64DecodeError(#[from] base64::DecodeError),
     #[error("Handshake couldn't complete")]
     HandshakeError,
+    #[error("Error sending on channel")]
+    SendError(#[from] SendError<Packet>),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@ use std::string::FromUtf8Error;
 use std::time::SystemTimeError;
 use thiserror::Error;
 
-use crossbeam::channel::SendError;
+use crossbeam::channel::{RecvError, RecvTimeoutError, SendError};
 
 use crate::packet::Packet;
 
@@ -18,7 +18,7 @@ pub enum AetherError {
     #[error("Link module stopped")]
     LinkStopped(&'static str),
     #[error("Receive timed out")]
-    RecvTimeout,
+    RecvTimeout(#[from] RecvTimeoutError),
     #[error("Link timed out")]
     LinkTimeout,
     #[error("Failed to set read timeout on socket")]
@@ -44,5 +44,7 @@ pub enum AetherError {
     #[error("Handshake couldn't complete")]
     HandshakeError,
     #[error("Error sending on channel")]
-    SendError(#[from] SendError<Packet>),
+    ChannelSendError(#[from] SendError<Packet>),
+    #[error("Error receiving on channel")]
+    ChannelRecvError(#[from] RecvError),
 }

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -275,6 +275,7 @@ impl Link {
         }
     }
 
+    /// Returns a [`Receiver`] to receive packets from the output queue
     pub fn get_receiver(&self) -> Result<Receiver<Packet>, AetherError> {
         match self.stop_flag.lock() {
             Ok(flag_lock) => {

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -288,7 +288,7 @@ impl Link {
     }
 
     /// Waits and blocks the current thread until the [`Link`] is empty
-    pub fn wait(&self) -> Result<(), AetherError> {
+    pub fn wait_empty(&self) -> Result<(), AetherError> {
         loop {
             match self.is_empty() {
                 Ok(empty) => {

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -274,6 +274,23 @@ impl Link {
             Err(_) => Err(AetherError::MutexLock("stop flag")),
         }
     }
+
+    pub fn get_receiver(&self) -> Result<Receiver<Packet>, AetherError> {
+        match self.stop_flag.lock() {
+            Ok(flag_lock) => {
+                let stop = *flag_lock;
+                drop(flag_lock);
+
+                if stop {
+                    Err(AetherError::LinkStopped("recv"))
+                } else {
+                    Ok(self.output_queue.1.clone())
+                }
+            }
+            Err(_) => Err(AetherError::MutexLock("stop flag")),
+        }
+    }
+
     /// Returns true if no more packets needs to be sent
     /// Checks if both primary queue and batch queue are empty
     pub fn is_empty(&self) -> Result<bool, AetherError> {

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -224,7 +224,7 @@ impl Link {
     /// # Returns
     /// * [`Vec<u8>`] - Buffer containing the received bytes
     /// # Errors
-    /// * [`AetherError::ReadTimeout`] - Timeout reached before receiving any bytes
+    /// * [`AetherError::RecvTimeout`] - Timeout reached before receiving any bytes
     /// * [`AetherError::LinkStopped`] - [`Link`] stopped before receiving any bytes
     ///
     /// Other general errors might occur (refer to [`AetherError`])

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -178,6 +178,7 @@ impl Link {
         }
     }
 
+    /// Get the [`SocketAddr`] of the peer
     pub fn get_addr(&self) -> SocketAddr {
         self.peer_addr
     }

--- a/src/link/receivethread.rs
+++ b/src/link/receivethread.rs
@@ -20,12 +20,12 @@ use crate::packet::Packet;
 pub struct OrderList {
     /// Last sequence number till which the packets are ordered.
     seq: u32,
-    /// [`Hashmap`] of packets by their sequence numbers
+    /// [`HashMap`] of packets by their sequence numbers
     list: HashMap<u32, Packet>,
 }
 
 impl OrderList {
-    /// Creates a new [`OrderList`] with the starting sequence number [`seq`].
+    /// Creates a new [`OrderList`] with the starting sequence number `seq`.
     pub fn new(seq: u32) -> OrderList {
         OrderList {
             seq,
@@ -74,17 +74,17 @@ pub struct ReceiveThread {
     socket: Arc<UdpSocket>,
     /// Address of the other peer
     _peer_addr: SocketAddr,
-    /// Reference to the output queue from [`Link`]
+    /// Reference to the output queue from [`crate::link::Link`]
     output_queue: Sender<Packet>,
-    /// Reference to the stop flag from [`Link`]
+    /// Reference to the stop flag from [`crate::link::Link`]
     stop_flag: Arc<Mutex<bool>>,
-    /// Reference to the [`AcknowledgementList`] from [`Link`]
+    /// Reference to the [`AcknowledgementList`] from [`crate::link::Link`]
     ack_list: Arc<Mutex<AcknowledgementList>>,
-    /// Reference to the [`AcknowledgementCheck`] from [`Link`]
+    /// Reference to the [`AcknowledgementCheck`] from [`crate::link::Link`]
     ack_check: Arc<Mutex<AcknowledgementCheck>>,
     /// [`OrderList`] used to order received packets by their sequence number
     order_list: OrderList,
-    /// Reference to receive sequence from [`Link`]
+    /// Reference to receive sequence from [`crate::link::Link`]
     _recv_seq: Arc<Mutex<u32>>,
     /// Current configuration for Aether
     config: Config,

--- a/src/peer/authentication.rs
+++ b/src/peer/authentication.rs
@@ -34,7 +34,7 @@ pub fn authenticate(
     let nonce_enc = match link.recv_timeout(recv_timeout) {
         Ok(data) => data,
         Err(err) => match err {
-            AetherError::RecvTimeout => return Err(AetherError::AuthenticationFailed(peer_uid)),
+            AetherError::RecvTimeout(_) => return Err(AetherError::AuthenticationFailed(peer_uid)),
             other => return Err(other),
         },
     };
@@ -49,7 +49,7 @@ pub fn authenticate(
     let nonce_recv = match link.recv_timeout(recv_timeout) {
         Ok(data) => data,
         Err(err) => match err {
-            AetherError::RecvTimeout => return Err(AetherError::AuthenticationFailed(peer_uid)),
+            AetherError::RecvTimeout(_) => return Err(AetherError::AuthenticationFailed(peer_uid)),
             other => return Err(other),
         },
     };

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -174,7 +174,7 @@ impl Aether {
 
             drop(connections_lock);
 
-            thread::sleep(Duration::from_millis(10));
+            thread::sleep(Duration::from_millis(self.config.aether.poll_time_us));
         }
     }
 

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -168,7 +168,7 @@ impl Aether {
 
             match peer.link.recv_timeout(Duration::from_millis(1)) {
                 Ok(data) => return Ok(data),
-                Err(AetherError::RecvTimeout) => {}
+                Err(AetherError::RecvTimeout(_)) => {}
                 Err(err) => return Err(err),
             }
 

--- a/tests/aether_test.rs
+++ b/tests/aether_test.rs
@@ -34,7 +34,7 @@ mod tests {
         thread::spawn(|| {
             run("rm -rf tmp && mkdir -p tmp && cd tmp && git clone https://github.com/Prototype-Aether/Aether-Tracker.git", false);
             run(
-                "cd tmp/Aether-Tracker && cargo run --bin server 8000",
+                "cd tmp/Aether-Tracker && TRACKER_PORT=8000 cargo run --bin server",
                 false,
             )
         });
@@ -62,10 +62,7 @@ mod tests {
 
         let send_str1 = format!("Hello {}", aether2.get_uid());
         aether1
-            .send_to(
-                aether2.get_uid(),
-                send_str1.clone().into_bytes(),
-            )
+            .send_to(aether2.get_uid(), send_str1.clone().into_bytes())
             .expect("unable to send to peer");
 
         let result = aether2
@@ -77,10 +74,7 @@ mod tests {
 
         let send_str2 = format!("Hello {}", aether1.get_uid());
         aether2
-            .send_to(
-                aether1.get_uid(),
-                send_str2.clone().into_bytes(),
-            )
+            .send_to(aether1.get_uid(), send_str2.clone().into_bytes())
             .expect("unable to send to peer");
 
         let result = aether1

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -109,7 +109,7 @@ mod tests {
                 link.send(x.clone()).unwrap();
             }
 
-            link.wait().unwrap();
+            link.wait_empty().unwrap();
             println!("Stopping sender");
 
             data
@@ -143,7 +143,7 @@ mod tests {
                 }
             }
 
-            link.wait().unwrap();
+            link.wait_empty().unwrap();
             println!("Stopping receiver");
             recv
         });


### PR DESCRIPTION
Since the previous implementation with `Arc<Mutex<VecDeque>>` was very inefficient, I changed primary queue and output queue to use [`crossbeam::channel::unbounded`](https://docs.rs/crossbeam/latest/crossbeam/channel/fn.unbounded.html) instead.

This should make the 2 queues much more efficient. This also helps make `recv_from` more efficient as now we just need to get a clone of the channel receiver and wait for it to respond with the data. This is unlike previous implementation in which we had to poll for new data by locking the `connections` list every few milliseconds.

The batch queue using `VecDeque` is not an issue as it is not shared and also it is used continuously and doesn't have to wait very often.