### PR TITLE
E2E Encryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "lazy_static"
@@ -249,9 +249,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
 
 [[package]]
 name = "linked-hash-map"
@@ -261,9 +261,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if",
 ]
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "openssl"
@@ -312,44 +312,43 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
@@ -368,16 +367,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.3",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
+ "getrandom 0.2.6",
 ]
 
 [[package]]
@@ -411,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c9613b5a66ab9ba26415184cfc41156594925a9cf3a2057e57f31ff145f6568"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "scopeguard"
@@ -423,18 +413,18 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -443,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.72"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa",
  "ryu",
@@ -466,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.82"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -1,11 +1,13 @@
+use std::fmt::{Debug, Formatter};
+
 use openssl::symm::{decrypt_aead, encrypt_aead, Cipher};
 
 use crate::{error::AetherError, util::gen_nonce};
 
 const EMPTY_BYTES: [u8; 0] = [];
-const IV_SIZE: usize = 16;
-const KEY_SIZE: usize = 32;
-const TAG_SIZE: usize = 16;
+pub const IV_SIZE: usize = 16;
+pub const KEY_SIZE: usize = 32;
+pub const TAG_SIZE: usize = 16;
 
 pub struct AetherCipher {
     cipher: Cipher,
@@ -79,6 +81,16 @@ impl From<Vec<u8>> for Encrypted {
             iv: bytes.drain(0..IV_SIZE).collect(),
             crypto_text: bytes,
         }
+    }
+}
+
+impl Debug for AetherCipher {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AetherCipher")
+            .field("cipher", &"AES-256-GCM")
+            .field("key", &base64::encode(self.key.clone()))
+            .field("iv", &self.iv)
+            .finish()
     }
 }
 

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -12,9 +12,10 @@ pub const IV_SIZE: usize = 16;
 pub const KEY_SIZE: usize = 32;
 pub const TAG_SIZE: usize = 16;
 
+#[derive(Clone)]
 pub struct AetherCipher {
     cipher: Cipher,
-    key: [u8; 32],
+    key: [u8; KEY_SIZE],
 }
 
 pub struct Encrypted {

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -91,7 +91,7 @@ impl Debug for AetherCipher {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AetherCipher")
             .field("cipher", &"AES-256-GCM")
-            .field("key", &base64::encode(self.key.clone()))
+            .field("key", &base64::encode(self.key))
             .finish()
     }
 }

--- a/src/encryption/mod.rs
+++ b/src/encryption/mod.rs
@@ -1,0 +1,122 @@
+use openssl::symm::{decrypt_aead, encrypt_aead, Cipher};
+
+use crate::{error::AetherError, util::gen_nonce};
+
+const EMPTY_BYTES: [u8; 0] = [];
+const IV_SIZE: usize = 16;
+const KEY_SIZE: usize = 32;
+const TAG_SIZE: usize = 16;
+
+pub struct AetherCipher {
+    cipher: Cipher,
+    key: Vec<u8>,
+    iv: Vec<u8>,
+}
+
+pub struct Encrypted {
+    pub crypto_text: Vec<u8>,
+    pub tag: Vec<u8>,
+    pub iv: Vec<u8>,
+    pub aad: Vec<u8>,
+}
+
+impl AetherCipher {
+    pub fn new() -> AetherCipher {
+        let cipher = Cipher::aes_256_gcm();
+        let key = gen_nonce(KEY_SIZE);
+        let iv = gen_nonce(IV_SIZE);
+
+        AetherCipher { cipher, key, iv }
+    }
+
+    pub fn encrypt_bytes(&self, plain_text: Vec<u8>) -> Result<Encrypted, AetherError> {
+        let mut tag = vec![0u8; TAG_SIZE];
+        let encrypted = encrypt_aead(
+            self.cipher,
+            &self.key,
+            Some(&self.iv),
+            &EMPTY_BYTES,
+            &plain_text,
+            &mut tag,
+        )?;
+
+        Ok(Encrypted {
+            crypto_text: encrypted,
+            tag,
+            iv: self.iv.clone(),
+            aad: EMPTY_BYTES.to_vec(),
+        })
+    }
+
+    pub fn decrypt_bytes(&self, crypto_text: Encrypted) -> Result<Vec<u8>, AetherError> {
+        Ok(decrypt_aead(
+            self.cipher,
+            &self.key,
+            Some(&crypto_text.iv),
+            &crypto_text.aad,
+            &crypto_text.crypto_text,
+            &crypto_text.tag,
+        )?)
+    }
+}
+
+impl From<Encrypted> for Vec<u8> {
+    fn from(mut encrypted: Encrypted) -> Self {
+        let mut result: Vec<u8> = Vec::new();
+        result.append(&mut encrypted.aad);
+        result.append(&mut encrypted.tag);
+        result.append(&mut encrypted.iv);
+        result.append(&mut encrypted.crypto_text);
+        result
+    }
+}
+
+impl From<Vec<u8>> for Encrypted {
+    fn from(mut bytes: Vec<u8>) -> Self {
+        Encrypted {
+            aad: EMPTY_BYTES.to_vec(),
+            tag: bytes.drain(0..TAG_SIZE).collect(),
+            iv: bytes.drain(0..IV_SIZE).collect(),
+            crypto_text: bytes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{encryption::Encrypted, util::gen_nonce};
+
+    use super::AetherCipher;
+
+    #[test]
+    fn encryption_test() {
+        let data = gen_nonce(512);
+
+        let cipher = AetherCipher::new();
+
+        let encrypted = cipher.encrypt_bytes(data.clone()).unwrap();
+
+        let decrypted = cipher.decrypt_bytes(encrypted).unwrap();
+
+        assert_eq!(data, decrypted);
+    }
+
+    #[test]
+    fn encoding_test() {
+        let data = gen_nonce(512);
+
+        let cipher = AetherCipher::new();
+
+        let encrypted = cipher.encrypt_bytes(data.clone()).unwrap();
+
+        // Encrypted data is converted to sequence of bytes and sent
+        let encrypted_raw: Vec<u8> = Vec::from(encrypted);
+
+        // Other end receives sequence of bytes as encrypted text
+        let received = Encrypted::from(encrypted_raw);
+
+        let decrypted = cipher.decrypt_bytes(received).unwrap();
+
+        assert_eq!(data, decrypted);
+    }
+}

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -71,6 +71,7 @@ pub struct Id {
 /// identities
 /// Different from `Id` as it is meant to be used to store only public key. So, only used to
 /// represent identity of other users
+#[derive(Debug, Clone)]
 pub struct PublicId {
     /// RSA public key defining the user
     rsa: Rsa<Public>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod acknowledgement;
 pub mod config;
+pub mod encryption;
 pub mod error;
 pub mod identity;
 pub mod link;

--- a/src/link/decryptionthread.rs
+++ b/src/link/decryptionthread.rs
@@ -1,0 +1,61 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use crossbeam::channel::{Receiver, RecvTimeoutError, Sender};
+
+use crate::{config::Config, encryption::AetherCipher, error::AetherError, packet::Packet};
+
+pub struct DecryptionThread {
+    cipher: AetherCipher,
+    receiver: Receiver<Packet>,
+    sender: Sender<Packet>,
+    stop_flag: Arc<Mutex<bool>>,
+    config: Config,
+}
+
+impl DecryptionThread {
+    pub fn new(
+        cipher: AetherCipher,
+        receiver: Receiver<Packet>,
+        sender: Sender<Packet>,
+        stop_flag: Arc<Mutex<bool>>,
+        config: Config,
+    ) -> DecryptionThread {
+        DecryptionThread {
+            cipher,
+            receiver,
+            sender,
+            stop_flag,
+            config,
+        }
+    }
+    pub fn start(&self) -> Result<(), AetherError> {
+        loop {
+            match self
+                .receiver
+                .recv_timeout(Duration::from_micros(self.config.link.poll_time_us))
+            {
+                Ok(mut packet) => {
+                    let encrypted = packet.payload;
+                    let decrypted = self.cipher.decrypt_bytes(encrypted.into())?;
+                    packet.payload = decrypted;
+                    packet.set_enc(false);
+                    self.sender.send(packet)?;
+                }
+                Err(RecvTimeoutError::Timeout) => {}
+                Err(err) => {
+                    return Err(AetherError::from(err));
+                }
+            };
+
+            let flag_lock = self.stop_flag.lock().expect("Error locking stop flag");
+            if *flag_lock {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -168,7 +168,7 @@ impl Link {
         self.thread_handles.push(recv_thread);
     }
 
-    pub fn enable_encryption(&self) -> Result<(), AetherError> {
+    pub fn enable_encryption(&mut self) -> Result<(), AetherError> {
         // Generate a secret
         let own_secret = gen_nonce(KEY_SIZE);
 
@@ -188,6 +188,11 @@ impl Link {
         let shared_secret = xor(own_secret, other_secret);
 
         // Instantiate a new cipher with the shared secret
+        let cipher = AetherCipher::new(shared_secret);
+
+        self.cipher = Some(cipher);
+
+        println!("{:?}", self.cipher);
 
         Ok(())
     }

--- a/src/link/mod.rs
+++ b/src/link/mod.rs
@@ -101,7 +101,10 @@ impl Link {
         let socket = Arc::new(socket);
 
         // if - let for errors
-        if let Err(_) = socket.set_read_timeout(Some(Duration::from_secs(1))) {
+        if socket
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .is_err()
+        {
             return Err(AetherError::SetReadTimeout);
         }
 

--- a/src/link/receivethread.rs
+++ b/src/link/receivethread.rs
@@ -75,7 +75,7 @@ pub struct ReceiveThread {
     /// Address of the other peer
     _peer_addr: SocketAddr,
     /// Reference to the output queue from [`crate::link::Link`]
-    output_queue: Sender<Packet>,
+    receive_queue: Sender<Packet>,
     /// Reference to the stop flag from [`crate::link::Link`]
     stop_flag: Arc<Mutex<bool>>,
     /// Reference to the [`AcknowledgementList`] from [`crate::link::Link`]
@@ -94,7 +94,7 @@ impl ReceiveThread {
     pub fn new(
         socket: Arc<UdpSocket>,
         peer_addr: SocketAddr,
-        output_queue: Sender<Packet>,
+        receive_queue: Sender<Packet>,
         stop_flag: Arc<Mutex<bool>>,
         ack_check: Arc<Mutex<AcknowledgementCheck>>,
         ack_list: Arc<Mutex<AcknowledgementList>>,
@@ -109,7 +109,7 @@ impl ReceiveThread {
         ReceiveThread {
             socket,
             _peer_addr: peer_addr,
-            output_queue,
+            receive_queue,
             stop_flag,
             ack_check,
             ack_list,
@@ -189,7 +189,7 @@ impl ReceiveThread {
         match self.order_list.insert(packet) {
             Ok(mut packets) => {
                 while let Some(p) = packets.pop_front() {
-                    self.output_queue
+                    self.receive_queue
                         .send(p)
                         .expect("Unable to push to output queue");
                 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -54,7 +54,8 @@ pub struct PacketFlags {
 impl PacketFlags {
     pub fn get_byte(&self) -> u8 {
         let mut byte: u8 = 0;
-        byte |= (self.p_type.clone() as u8) << 4;
+        let p_type: u8 = self.p_type.clone().into();
+        byte |= p_type << 4;
         if self.ack {
             byte |= 1 << 3;
         }
@@ -111,6 +112,20 @@ impl Packet {
         }
     }
 
+    /// Set the packet encrypted flag
+    ///
+    /// # Argument
+    ///
+    /// * `enc` - Boolean representing if the packet is encrypted or not
+    pub fn set_enc(&mut self, enc: bool) {
+        self.flags.enc = enc;
+    }
+
+    /// Set the packet as a meta packet with the given meta data
+    ///
+    /// # Arguments
+    ///
+    /// * `meta` - The meta data to assign to this meta packet
     pub fn set_meta(&mut self, meta: PacketMeta) {
         self.is_meta = true;
         self.meta = meta;
@@ -125,7 +140,8 @@ impl Packet {
         self.ack = ack;
         self.flags.ack = true;
     }
-    ///Append payload Vec<u8> to the packet
+
+    /// Append payload Vec<u8> to the packet
     /// also assigns the length of the packet
     ///
     /// # Arguments
@@ -134,6 +150,7 @@ impl Packet {
     pub fn append_payload(&mut self, payload: Vec<u8>) {
         self.payload.extend(payload);
     }
+
     /// Compile the data in the packet into packet struct
     ///
     /// # Arguments
@@ -264,7 +281,7 @@ mod tests {
 
     #[test]
     fn compile_test() {
-        let mut pack = packet::Packet::new(PType::Data, 32850943);
+        let mut pack = packet::Packet::new(PType::KeyExchange, 32850943);
         let mut ack_list = AcknowledgementList::new(329965);
         ack_list.insert(329966);
         ack_list.insert(329967);

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -10,6 +10,7 @@ pub enum PType {
     Data,
     AckOnly,
     Initiation,
+    KeyExchange,
     Extended,
 }
 
@@ -19,6 +20,7 @@ impl From<PType> for u8 {
             PType::Data => 0,
             PType::AckOnly => 1,
             PType::Initiation => 2,
+            PType::KeyExchange => 7,
             PType::Extended => 15,
         }
     }
@@ -26,10 +28,11 @@ impl From<PType> for u8 {
 
 impl From<u8> for PType {
     fn from(p_type: u8) -> PType {
-        match Option::from(p_type) {
-            Some(0) => PType::Data,
-            Some(1) => PType::AckOnly,
-            Some(2) => PType::Initiation,
+        match p_type {
+            0 => PType::Data,
+            1 => PType::AckOnly,
+            2 => PType::Initiation,
+            7 => PType::KeyExchange,
             _ => PType::Extended,
         }
     }

--- a/src/peer/authentication.rs
+++ b/src/peer/authentication.rs
@@ -9,7 +9,7 @@ use rand::{thread_rng, Rng};
 use crate::{config::Config, link::Link};
 
 /// Size of the nonce to be used in authentication in bytes
-pub const NONCE_SIZE: u8 = 32;
+pub const NONCE_SIZE: usize = 32;
 
 pub fn authenticate(
     link: Link,

--- a/src/peer/handshake.rs
+++ b/src/peer/handshake.rs
@@ -1,5 +1,5 @@
 use crate::error::AetherError;
-use crate::identity::Id;
+use crate::identity::{Id, PublicId};
 use crate::{acknowledgement::Acknowledgement, config::Config, packet::Packet};
 use crate::{link::Link, packet::PType};
 use std::io::ErrorKind;
@@ -127,8 +127,10 @@ pub fn handshake(
         }
     }
 
+    let peer_id = PublicId::from_base64(&peer_uid)?;
+
     // Start the link
-    let mut link = Link::new(private_id, socket, address, seq, recv_seq, config)?;
+    let mut link = Link::new(private_id, socket, address, peer_id, seq, recv_seq, config)?;
     link.start();
     Ok(link)
 }

--- a/src/peer/handshake.rs
+++ b/src/peer/handshake.rs
@@ -23,8 +23,9 @@ pub fn handshake(
 
     let ack: bool;
 
-    if let Err(_) =
-        socket.set_read_timeout(Some(Duration::from_millis(config.handshake.peer_poll_time)))
+    if socket
+        .set_read_timeout(Some(Duration::from_millis(config.handshake.peer_poll_time)))
+        .is_err()
     {
         return Err(AetherError::SetReadTimeout);
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -55,3 +55,7 @@ pub fn gen_nonce(size: usize) -> Vec<u8> {
     OsRng.fill_bytes(&mut buf);
     buf
 }
+
+pub fn xor(lhs: Vec<u8>, rhs: Vec<u8>) -> Vec<u8> {
+    lhs.iter().zip(rhs).map(|(x, y)| x ^ y).collect()
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -37,7 +37,7 @@ pub fn compile_u16(nu16: u16) -> Vec<u8> {
     vec![(nu16 >> 8) as u8, nu16 as u8]
 }
 
-/// Generate a random nonce of the given size in bytes
+/// Generate a cryptographically secure random nonce of the given size in bytes
 ///
 /// # Arguments
 ///
@@ -50,8 +50,8 @@ pub fn compile_u16(nu16: u16) -> Vec<u8> {
 /// // to generate a 16 bytes nonce
 /// let nonce = gen_nonce(16);
 /// ```
-pub fn gen_nonce(size: u8) -> Vec<u8> {
-    let mut buf = vec![0u8; size as usize];
+pub fn gen_nonce(size: usize) -> Vec<u8> {
+    let mut buf = vec![0u8; size];
     OsRng.fill_bytes(&mut buf);
     buf
 }

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -1,13 +1,13 @@
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
+    use std::net::{IpAddr, Ipv4Addr, UdpSocket};
     use std::thread;
     use std::time::Duration;
 
     use aether_lib::config::Config;
     use aether_lib::identity::{Id, PublicId};
     use aether_lib::link::Link;
-    use aether_lib::peer::handshake::handshake;
+
     #[test]
     pub fn link_test() {
         let socket1 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
@@ -51,18 +51,6 @@ mod tests {
         link1.start();
         link2.start();
 
-        crossbeam::thread::scope(|s| {
-            let handle1 = s.spawn(|_| {
-                link1.enable_encryption().unwrap();
-            });
-            let handle2 = s.spawn(|_| {
-                link2.enable_encryption().unwrap();
-            });
-            handle1.join().unwrap();
-            handle2.join().unwrap();
-        })
-        .unwrap();
-
         let mut data: Vec<Vec<u8>> = Vec::new();
 
         for i in 1..100 {
@@ -95,99 +83,86 @@ mod tests {
     }
 
     #[test]
-    pub fn handshake_test() {
+    pub fn encrypted_link_test() {
         let socket1 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
         let socket2 = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
+
+        let mut peer_addr1 = socket1.local_addr().unwrap();
+        let mut peer_addr2 = socket2.local_addr().unwrap();
 
         let id1 = Id::new().unwrap();
         let id2 = Id::new().unwrap();
 
-        let uid1 = id1.public_key_to_base64().unwrap();
-        let uid2 = id2.public_key_to_base64().unwrap();
+        let id1_public = PublicId::from_base64(&id1.public_key_to_base64().unwrap()).unwrap();
+        let id2_public = PublicId::from_base64(&id2.public_key_to_base64().unwrap()).unwrap();
 
-        let uid1_clone = uid1.clone();
-        let uid2_clone = uid2.clone();
+        peer_addr1.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+        peer_addr2.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
 
-        let peer_addr1 = SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            socket1.local_addr().unwrap().port(),
-        );
-        let peer_addr2 = SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-            socket2.local_addr().unwrap().port(),
-        );
+        let mut link1 = Link::new(
+            id1,
+            socket1,
+            peer_addr2,
+            id2_public,
+            0,
+            1000,
+            Config::default(),
+        )
+        .unwrap();
+        let mut link2 = Link::new(
+            id2,
+            socket2,
+            peer_addr1,
+            id1_public,
+            1000,
+            0,
+            Config::default(),
+        )
+        .unwrap();
 
         println!("{:?} {:?}", peer_addr1, peer_addr2);
 
-        let len = 100;
+        link1.start();
+        link2.start();
+        crossbeam::thread::scope(|s| {
+            let handle1 = s.spawn(|_| {
+                link1.enable_encryption().unwrap();
+            });
+            let handle2 = s.spawn(|_| {
+                link2.enable_encryption().unwrap();
+            });
+            handle1.join().unwrap();
+            handle2.join().unwrap();
+        })
+        .unwrap();
+        let mut data: Vec<Vec<u8>> = Vec::new();
 
-        let send_thread = thread::spawn(move || {
-            let link = handshake(
-                id1,
-                socket1,
-                peer_addr2,
-                uid1,
-                uid2_clone,
-                Config::default(),
-            )
-            .expect("Handshake failed");
-
-            let mut data: Vec<Vec<u8>> = Vec::new();
-
-            for i in 0..len {
-                data.push(format!("Hello {}", i).as_bytes().to_vec());
-            }
-
-            for x in &data {
-                link.send(x.clone()).unwrap();
-            }
-
-            link.wait_empty().unwrap();
-            println!("Stopping sender");
-
-            data
-        });
-
-        let recv_thread = thread::spawn(move || {
-            let link = handshake(
-                id2,
-                socket2,
-                peer_addr1,
-                uid2,
-                uid1_clone,
-                Config::default(),
-            )
-            .expect("Handshake failed");
-
-            let mut count = 0;
-            let mut recv: Vec<Vec<u8>> = Vec::new();
-            loop {
-                match link.recv() {
-                    Ok(recved_data) => {
-                        count += 1;
-                        recv.push(recved_data);
-                        if count >= len {
-                            break;
-                        }
-                    }
-                    Err(err) => {
-                        panic!("Error {}", err);
-                    }
-                }
-            }
-
-            link.wait_empty().unwrap();
-            println!("Stopping receiver");
-            recv
-        });
-
-        let data = send_thread.join().expect("Send thread panicked");
-        let recv = recv_thread.join().expect("Receive thread panicked");
-
-        for i in 0..recv.len() {
-            assert_eq!(recv[i], data[i]);
+        for i in 1..100 {
+            data.push(format!("Hello {}", i).as_bytes().to_vec());
         }
 
-        println!("Stopping");
+        for x in &data {
+            link1.send(x.clone()).unwrap();
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        let mut count = 0;
+        let mut recv: Vec<Vec<u8>> = Vec::new();
+        loop {
+            if let Ok(recved_data) = link2.recv() {
+                count += 1;
+                recv.push(recved_data);
+                if count >= data.len() {
+                    break;
+                }
+            }
+        }
+
+        for i in 0..recv.len() {
+            let a = String::from_utf8(recv[i].clone()).unwrap();
+            let b = String::from_utf8(data[i].clone()).unwrap();
+            println!("{} == {}", a, b);
+            assert_eq!(recv[i], data[i]);
+        }
     }
 }

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -5,7 +5,7 @@ mod tests {
     use std::time::Duration;
 
     use aether_lib::config::Config;
-    use aether_lib::identity::Id;
+    use aether_lib::identity::{Id, PublicId};
     use aether_lib::link::Link;
     use aether_lib::peer::handshake::handshake;
     #[test]
@@ -19,11 +19,32 @@ mod tests {
         let id1 = Id::new().unwrap();
         let id2 = Id::new().unwrap();
 
+        let id1_public = PublicId::from_base64(&id1.public_key_to_base64().unwrap()).unwrap();
+        let id2_public = PublicId::from_base64(&id2.public_key_to_base64().unwrap()).unwrap();
+
         peer_addr1.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
         peer_addr2.set_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
 
-        let mut link1 = Link::new(id1, socket1, peer_addr2, 0, 1000, Config::default()).unwrap();
-        let mut link2 = Link::new(id2, socket2, peer_addr1, 1000, 0, Config::default()).unwrap();
+        let mut link1 = Link::new(
+            id1,
+            socket1,
+            peer_addr2,
+            id2_public,
+            0,
+            1000,
+            Config::default(),
+        )
+        .unwrap();
+        let mut link2 = Link::new(
+            id2,
+            socket2,
+            peer_addr1,
+            id1_public,
+            1000,
+            0,
+            Config::default(),
+        )
+        .unwrap();
 
         println!("{:?} {:?}", peer_addr1, peer_addr2);
 

--- a/tests/link_test.rs
+++ b/tests/link_test.rs
@@ -51,6 +51,18 @@ mod tests {
         link1.start();
         link2.start();
 
+        crossbeam::thread::scope(|s| {
+            let handle1 = s.spawn(|_| {
+                link1.enable_encryption().unwrap();
+            });
+            let handle2 = s.spawn(|_| {
+                link2.enable_encryption().unwrap();
+            });
+            handle1.join().unwrap();
+            handle2.join().unwrap();
+        })
+        .unwrap();
+
         let mut data: Vec<Vec<u8>> = Vec::new();
 
         for i in 1..100 {


### PR DESCRIPTION
Implemented E2E encryption based on AES256-GCM (AEAD). This will allow for confidentiality due to AES encryption as well as integrity due to GCM. However we are not using the "Associated Data" part of this cipher.

Encryption is enabled after authentication is complete. A key exchange is carried out using the following algorithm and the shared secret is Hashed using SHA256 to get the shared secret key.
- Alice generates a random secret and encrypts it with Bob's public key
- Alice then sends the encrypted secret to Bob
- Bob decrypts the secret using his private key
- This is done the other way too
- Once both have each other's secrets, they XOR their secret with other's secret to get a common shared secret
- The secret is then hashed by SHA256 to get a shared secret key which is used for AES256 encryption

Since both the peer's need to do start the key exchange together, keeping the key exchange symmetric (the same sequence of steps followed on each side) makes the process simple. Using PKC to encrypt secrets ensures that a man in the middle won't be able to snoop on the secret.

The Link module had a few changes -
- `send()` now checks if a cipher exists (encryption is enabled). If so, any payload received is first encrypted and the `ENC` flag on the packet is set to `1`
- There are 2 queue's `receive_queue` and `output_queue`
- `receive_queue` receives the packets from `ReceiveThread`
- If encryption is enabled `DecryptionThread` receives packets from `receive_queue`, decrypts them and sends them to `output_queue`
- If encryption is enabled `get_receiver()` returns `Receiver` for `output_queue`
- Otherwise, `get_receiver()` returns `Receiver` for `receive_queue`

Thus, interface to the `Link` module remains mostly the same but `enable_encryption()` needs to be called on both sides.

The limitation right now is that both peers need to enable encryption at the same time. One side cannot request encryption.