### PR TITLE
Wait Connection wait for Connection Only

### DIFF
--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -177,27 +177,12 @@ impl Aether {
     }
 
     pub fn wait_connection(&self, uid: &str) -> Result<u8, u8> {
-        if !self.is_initialized(uid) {
-            if self.is_connecting(uid) {
-                while self.is_connecting(uid) {
-                    thread::sleep(Duration::from_millis(
-                        self.config.aether.connection_check_delay,
-                    ));
-                }
-                Ok(0)
-            } else if self.is_connected(uid) {
-                Ok(0)
-            } else {
-                Err(0)
-            }
-        } else {
-            while !self.is_connected(uid) {
-                thread::sleep(Duration::from_millis(
-                    self.config.aether.connection_check_delay,
-                ));
-            }
-            Ok(0)
+        while !self.is_connected(uid) {
+            thread::sleep(Duration::from_millis(
+                self.config.aether.connection_check_delay,
+            ));
         }
+        Ok(0)
     }
 
     pub fn is_connected(&self, uid: &str) -> bool {


### PR DESCRIPTION
Changed `wait_connection()` function of `Aether` to wait for a connection to be established whether it is initialized or not. Earlier, the function would return an error in a connection was not already initialized with the other peer.

Thus, `wait_connection()` now just waits for `is_connected()` to be true. I think this makes more sense in terms of waiting for a connection with another peer.