### PR TITLE
Enabled vendored feature for openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde_yaml = "0.8"
 home = "0.5"
 log = "0.4"
 thiserror = "1.0"
-openssl = "0.10"
+openssl = { version = "0.10", features = ["vendored"] }
 base64 = "0.13"
 crossbeam = "0.8"
 


### PR DESCRIPTION
While building for other platforms such as windows, we need to cross compile. Providing system `openssl` for compiling to the same platform is not a problem, but when compiling for another platform such as windows, the system `openssl` installation cannot be used. So, it is better to enable the `vendored` feature in `openssl` in order to ensure `openssl` is compiled from source for the target system.