### PR TITLE
Download and run released tracker

### DIFF
--- a/tests/aether_test.rs
+++ b/tests/aether_test.rs
@@ -131,15 +131,13 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     pub fn aether_test() {
         // Run the tracker server
         thread::spawn(|| {
-            run("rm -rf tmp && mkdir -p tmp && cd tmp && git clone https://github.com/Prototype-Aether/Aether-Tracker.git", false);
-            run(
-                "cd tmp/Aether-Tracker && TRACKER_PORT=8000 cargo run --bin server",
-                false,
-            )
+            run("mkdir -p tmp", false);
+            run("curl -L https://github.com/Prototype-Aether/Aether-Tracker/releases/latest/download/aether-tracker-server-x86_64-unknown-linux-gnu --output tmp/aether-tracker-server", false);
+            run("chmod +x tmp/aether-tracker-server", false);
+            run("TRACKER_PORT=8000 tmp/aether-tracker-server", false);
         });
 
         let tracker_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8000);
@@ -195,11 +193,10 @@ mod tests {
     pub fn aether_long_test() {
         // Run the tracker server
         thread::spawn(|| {
-            run("rm -rf tmp && mkdir -p tmp && cd tmp && git clone https://github.com/Prototype-Aether/Aether-Tracker.git", false);
-            run(
-                "cd tmp/Aether-Tracker && TRACKER_PORT=8000 cargo run --bin server",
-                false,
-            )
+            run("mkdir -p tmp", false);
+            run("curl -L https://github.com/Prototype-Aether/Aether-Tracker/releases/latest/download/aether-tracker-server-x86_64-unknown-linux-gnu --output tmp/aether-tracker-server", false);
+            run("chmod +x tmp/aether-tracker-server", false);
+            run("TRACKER_PORT=8000 tmp/aether-tracker-server", false);
         });
 
         let tracker_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8000);


### PR DESCRIPTION
Download and Run the released tracker instead of cloning the repository and compiling on each test (which was extremely inefficient)

I am still looking into making use of Docker Compose for this. The current issue is that Docker creates its own subnet for the tracker whereas the tracker is required to be on the open internet so as to read the peer IPs properly. I am looking into how to setup the network in docker properly for this.